### PR TITLE
Makes v8upgrade also run v8build and syncsubdeps

### DIFF
--- a/.github/workflows/leakcheck.yml
+++ b/.github/workflows/leakcheck.yml
@@ -6,6 +6,7 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/syncsubdeps.yml
+++ b/.github/workflows/syncsubdeps.yml
@@ -7,6 +7,7 @@ on:
     paths:
     - "deps/*_*/**"
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   sync:

--- a/.github/workflows/v8build.yml
+++ b/.github/workflows/v8build.yml
@@ -8,6 +8,7 @@ on:
         paths:
         - deps/latest_v8_hash
     workflow_dispatch:
+    workflow_call:
 
 jobs:
     build_common:

--- a/.github/workflows/v8upgrade.yml
+++ b/.github/workflows/v8upgrade.yml
@@ -44,3 +44,13 @@ jobs:
         - name: Create Summary
           run: |
               echo "Commit: https://github.com/tommie/v8go/commit/${{ steps.commit.outputs.commit_long_sha }}" >>"$GITHUB_STEP_SUMMARY"
+
+    build:
+        name: Run V8 Build
+        needs: upgrade
+        uses: ./.github/workflows/v8build.yml
+
+    syncsubdeps:
+        name: Run Sync Submodule Dependencies
+        needs: build
+        uses: ./.github/workflows/syncsubdeps.yml


### PR DESCRIPTION
GitHub doesn't run triggers by default when using the standard GitHub token.