### PR TITLE
Get `console` messages to Go code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support to setup an `Inspector`, and `InspectorClient` to receive output from `console` messages in JS code.
+
 ### Changed
 
 ## [v0.27.0] - 2024-12-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Add support to setup an `Inspector`, and `InspectorClient` to receive output from `console` messages in JS code.
 
 ### Changed

--- a/function_template.go
+++ b/function_template.go
@@ -78,7 +78,10 @@ func NewFunctionTemplate(iso *Isolate, callback FunctionCallback) *FunctionTempl
 // NewFunctionTemplateWithError creates a FunctionTemplate for a given
 // callback. If the callback returns an error, it will be thrown as a
 // JS error.
-func NewFunctionTemplateWithError(iso *Isolate, callback FunctionCallbackWithError) *FunctionTemplate {
+func NewFunctionTemplateWithError(
+	iso *Isolate,
+	callback FunctionCallbackWithError,
+) *FunctionTemplate {
 	if iso == nil {
 		panic("nil Isolate argument not supported")
 	}
@@ -111,7 +114,12 @@ func (tmpl *FunctionTemplate) GetFunction(ctx *Context) *Function {
 // to workaround an ERROR_COMMITMENT_LIMIT error on windows that was detected in CI.
 //
 //export goFunctionCallback
-func goFunctionCallback(ctxref int, cbref int, thisAndArgs *C.ValuePtr, argsCount int) (rval C.ValuePtr, rerr C.ValuePtr) {
+func goFunctionCallback(
+	ctxref int,
+	cbref int,
+	thisAndArgs *C.ValuePtr,
+	argsCount int,
+) (rval C.ValuePtr, rerr C.ValuePtr) {
 	ctx := getContext(ctxref)
 
 	this := *thisAndArgs

--- a/inspector.cc
+++ b/inspector.cc
@@ -53,7 +53,6 @@ InspectorClientPtr NewInspectorClient(int callbackRef) {
 }
 
 void InspectorContextCreated(InspectorPtr inspector, ContextPtr context) {
-  printf("Create from C++");
   LOCAL_CONTEXT(context);
   int groupId = 1;
   StringView name = StringView((const uint8_t*)"Test", 4);

--- a/inspector.cc
+++ b/inspector.cc
@@ -1,0 +1,30 @@
+#include "deps/include/v8-inspector.h"
+
+#include "inspector.h"
+
+using namespace v8;
+using namespace v8_inspector;
+
+class InspectorClient : public V8InspectorClient {};
+
+extern "C" {
+
+InspectorPtr CreateInspector(v8Isolate* iso, InspectorClientPtr client) {
+  InspectorPtr inspector = V8Inspector::create(iso, client).release();
+  return inspector;
+}
+
+void DeleteInspector(InspectorPtr inspector) {
+  delete inspector;
+}
+
+/********** InspectorClient **********/
+
+InspectorClientPtr NewInspectorClient() {
+  return new InspectorClient();
+}
+
+void DeleteInspectorClient(InspectorClientPtr client) {
+  delete client;
+}
+}

--- a/inspector.cc
+++ b/inspector.cc
@@ -71,8 +71,7 @@ v8InspectorClient* NewInspectorClient(uintptr_t cgoHandle) {
 void InspectorContextCreated(v8Inspector* inspector, ContextPtr context) {
   LOCAL_CONTEXT(context);
   int groupId = 1;
-  StringView name = StringView((const uint8_t*)"Test", 4);
-  V8ContextInfo info = V8ContextInfo(local_ctx, groupId, name);
+  V8ContextInfo info = V8ContextInfo(local_ctx, groupId, StringView());
   inspector->contextCreated(info);
 }
 

--- a/inspector.cc
+++ b/inspector.cc
@@ -5,7 +5,12 @@
 using namespace v8;
 using namespace v8_inspector;
 
-class InspectorClient : public V8InspectorClient {};
+class InspectorClient : public V8InspectorClient {
+  int _callbackRef;
+
+ public:
+  InspectorClient(int callbackRef) { _callbackRef = callbackRef; }
+};
 
 extern "C" {
 
@@ -20,8 +25,8 @@ void DeleteInspector(InspectorPtr inspector) {
 
 /********** InspectorClient **********/
 
-InspectorClientPtr NewInspectorClient() {
-  return new InspectorClient();
+InspectorClientPtr NewInspectorClient(int callbackRef) {
+  return new InspectorClient(callbackRef);
 }
 
 void DeleteInspectorClient(InspectorClientPtr client) {

--- a/inspector.cc
+++ b/inspector.cc
@@ -46,22 +46,22 @@ void InspectorClient::consoleAPIMessage(int contextGroupId,
 
 extern "C" {
 
-InspectorPtr CreateInspector(v8Isolate* iso, InspectorClientPtr client) {
-  InspectorPtr inspector = V8Inspector::create(iso, client).release();
+v8Inspector* CreateInspector(v8Isolate* iso, v8InspectorClient* client) {
+  v8Inspector* inspector = V8Inspector::create(iso, client).release();
   return inspector;
 }
 
-void DeleteInspector(InspectorPtr inspector) {
+void DeleteInspector(v8Inspector* inspector) {
   delete inspector;
 }
 
 /********** InspectorClient **********/
 
-InspectorClientPtr NewInspectorClient(uintptr_t callbackRef) {
+v8InspectorClient* NewInspectorClient(uintptr_t callbackRef) {
   return new InspectorClient(callbackRef);
 }
 
-void InspectorContextCreated(InspectorPtr inspector, ContextPtr context) {
+void InspectorContextCreated(v8Inspector* inspector, ContextPtr context) {
   LOCAL_CONTEXT(context);
   int groupId = 1;
   StringView name = StringView((const uint8_t*)"Test", 4);
@@ -69,12 +69,12 @@ void InspectorContextCreated(InspectorPtr inspector, ContextPtr context) {
   inspector->contextCreated(info);
 }
 
-void InspectorContextDestroyed(InspectorPtr inspector, ContextPtr context) {
+void InspectorContextDestroyed(v8Inspector* inspector, ContextPtr context) {
   LOCAL_CONTEXT(context);
   inspector->contextDestroyed(local_ctx);
 }
 
-void DeleteInspectorClient(InspectorClientPtr client) {
+void DeleteInspectorClient(v8InspectorClient* client) {
   delete client;
 }
 }

--- a/inspector.cc
+++ b/inspector.cc
@@ -8,7 +8,7 @@ using namespace v8;
 using namespace v8_inspector;
 
 /**
- * InspectorClient is an implementation v8_inspector::V8InspectorClient that is
+ * InspectorClient is an implementation of v8_inspector::V8InspectorClient that is
  * designed to be able to call back to Go code to a specific instance identified
  * by a cgo handle.
  *

--- a/inspector.cc
+++ b/inspector.cc
@@ -8,10 +8,10 @@ using namespace v8;
 using namespace v8_inspector;
 
 class InspectorClient : public V8InspectorClient {
-  int _callbackRef;
+  uintptr_t _callbackRef;
 
  public:
-  InspectorClient(int callbackRef) { _callbackRef = callbackRef; }
+  InspectorClient(uintptr_t callbackRef) { _callbackRef = callbackRef; }
   void consoleAPIMessage(int contextGroupId,
                          v8::Isolate::MessageErrorLevel level,
                          const StringView& message,
@@ -57,7 +57,7 @@ void DeleteInspector(InspectorPtr inspector) {
 
 /********** InspectorClient **********/
 
-InspectorClientPtr NewInspectorClient(int callbackRef) {
+InspectorClientPtr NewInspectorClient(uintptr_t callbackRef) {
   return new InspectorClient(callbackRef);
 }
 

--- a/inspector.cc
+++ b/inspector.cc
@@ -11,10 +11,7 @@ class InspectorClient : public V8InspectorClient {
   int _callbackRef;
 
  public:
-  InspectorClient(int callbackRef) {
-    _callbackRef = callbackRef;
-    printf("Client from C++");
-  }
+  InspectorClient(int callbackRef) { _callbackRef = callbackRef; }
   void consoleAPIMessage(int contextGroupId,
                          v8::Isolate::MessageErrorLevel level,
                          const StringView& message,
@@ -31,15 +28,11 @@ void InspectorClient::consoleAPIMessage(int contextGroupId,
                                         unsigned lineNumber,
                                         unsigned columnNumber,
                                         V8StackTrace*) {
-  printf("Hello from C++");
-  goHandleConsoleAPIMessageCallback(_callbackRef);
-  // if (message.is8Bit()) {
-  //   goConsoleAPIMessageUtf8(level, lineNumber, (char*)message.characters8());
-  // } else {
-  //   goConsoleAPIMessageUtf16(level, lineNumber,
-  //   (char*)message.characters16(),
-  //                            message.length() * 2);
-  // }
+  StringViewData msg;
+  msg.is8bit = message.is8Bit();
+  msg.data = message.characters8();
+  msg.length = message.length();
+  goHandleConsoleAPIMessageCallback(_callbackRef, contextGroupId, level, msg);
 }
 
 extern "C" {

--- a/inspector.cc
+++ b/inspector.cc
@@ -1,5 +1,7 @@
 #include "deps/include/v8-inspector.h"
 
+#include "_cgo_export.h"
+#include "context-macros.h"
 #include "inspector.h"
 
 using namespace v8;
@@ -9,8 +11,36 @@ class InspectorClient : public V8InspectorClient {
   int _callbackRef;
 
  public:
-  InspectorClient(int callbackRef) { _callbackRef = callbackRef; }
+  InspectorClient(int callbackRef) {
+    _callbackRef = callbackRef;
+    printf("Client from C++");
+  }
+  void consoleAPIMessage(int contextGroupId,
+                         v8::Isolate::MessageErrorLevel level,
+                         const StringView& message,
+                         const StringView& url,
+                         unsigned lineNumber,
+                         unsigned columnNumber,
+                         V8StackTrace*) override;
 };
+
+void InspectorClient::consoleAPIMessage(int contextGroupId,
+                                        v8::Isolate::MessageErrorLevel level,
+                                        const StringView& message,
+                                        const StringView& url,
+                                        unsigned lineNumber,
+                                        unsigned columnNumber,
+                                        V8StackTrace*) {
+  printf("Hello from C++");
+  goHandleConsoleAPIMessageCallback(_callbackRef);
+  // if (message.is8Bit()) {
+  //   goConsoleAPIMessageUtf8(level, lineNumber, (char*)message.characters8());
+  // } else {
+  //   goConsoleAPIMessageUtf16(level, lineNumber,
+  //   (char*)message.characters16(),
+  //                            message.length() * 2);
+  // }
+}
 
 extern "C" {
 
@@ -27,6 +57,20 @@ void DeleteInspector(InspectorPtr inspector) {
 
 InspectorClientPtr NewInspectorClient(int callbackRef) {
   return new InspectorClient(callbackRef);
+}
+
+void InspectorContextCreated(InspectorPtr inspector, ContextPtr context) {
+  printf("Create from C++");
+  LOCAL_CONTEXT(context);
+  int groupId = 1;
+  StringView name = StringView((const uint8_t*)"Test", 4);
+  V8ContextInfo info = V8ContextInfo(local_ctx, groupId, name);
+  inspector->contextCreated(info);
+}
+
+void InspectorContextDestroyed(InspectorPtr inspector, ContextPtr context) {
+  LOCAL_CONTEXT(context);
+  inspector->contextDestroyed(local_ctx);
 }
 
 void DeleteInspectorClient(InspectorClientPtr client) {

--- a/inspector.go
+++ b/inspector.go
@@ -142,7 +142,7 @@ func stringViewToString(d C.StringViewData) string {
 
 //export goHandleConsoleAPIMessageCallback
 func goHandleConsoleAPIMessageCallback(
-	callbackRef C.uintptr_t,
+	cgoHandle C.uintptr_t,
 	contextGroupId C.int,
 	errorLevel C.int,
 	message C.StringViewData,
@@ -150,9 +150,8 @@ func goHandleConsoleAPIMessageCallback(
 	lineNumber C.uint,
 	columnNumber C.uint,
 ) {
-	handle := cgo.Handle(callbackRef)
+	handle := cgo.Handle(cgoHandle)
 	if client, ok := handle.Value().(ConsoleAPIMessageHandler); ok {
-		// TODO, Stack trace
 		client.ConsoleAPIMessage(ConsoleAPIMessage{
 			contextGroupId: int(contextGroupId),
 			ErrorLevel:     MessageErrorLevel(errorLevel),

--- a/inspector.go
+++ b/inspector.go
@@ -2,6 +2,10 @@ package v8go
 
 // #include "inspector.h"
 import "C"
+import (
+	"sync"
+	"unsafe"
+)
 
 type Inspector struct {
 	ptr C.InspectorPtr
@@ -9,6 +13,68 @@ type Inspector struct {
 
 type InspectorClient struct {
 	ptr C.InspectorClientPtr
+}
+
+type MessageErrorLevel int
+
+// registry is a simple map of int->something. Allows passing an int to C-code
+// that can be used in a callback; then Go code can retrieve the right object
+// afterwards.
+// This can be generalised, e.g. Isolate has similar functionality handling
+// callback functions
+type registry[T any] struct {
+	entries map[C.int]T
+	id      C.int
+	lock    sync.RWMutex
+}
+
+func newRegistry[T any]() *registry[T] {
+	return &registry[T]{
+		entries: make(map[C.int]T),
+	}
+}
+
+var clientRegistry = newRegistry[*InspectorClient]()
+
+func (r *registry[T]) register(instance T) C.int {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.id++
+	r.entries[r.id] = instance
+	return r.id
+}
+
+func (r *registry[T]) unregister(id C.int) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	delete(r.entries, id)
+}
+
+func (r *registry[T]) get(id C.int) T {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	// What if not found? Return two parameters? Panic? (my preference)
+	return r.entries[id]
+}
+
+type ConsoleAPIMessage struct {
+	contextGroupId int
+	errorLevel     MessageErrorLevel
+	message        string
+	url            string
+	lineNumber     int
+	columnNumber   int
+	// stackTrace StackTrace
+}
+
+type ConsoleAPIMessageHandler interface {
+	ConsoleAPIMessage(message ConsoleAPIMessage)
+}
+
+type ConsoleAPIMessageHandlerFunc func(msg ConsoleAPIMessage)
+
+func (f ConsoleAPIMessageHandlerFunc) ConsoleAPIMessage(msg ConsoleAPIMessage) {
+	f(msg)
 }
 
 func NewInspector(iso *Isolate, client *InspectorClient) *Inspector {
@@ -22,11 +88,19 @@ func (i *Inspector) Dispose() {
 	C.DeleteInspector(i.ptr)
 }
 
-func NewInspectorClient() *InspectorClient {
-	ptr := C.NewInspectorClient()
-	return &InspectorClient{ptr: ptr}
+func NewInspectorClient(handler ConsoleAPIMessageHandler) *InspectorClient {
+	result := &InspectorClient{}
+	ref := clientRegistry.register(result)
+	result.ptr = C.NewInspectorClient(ref)
+	return result
 }
 
 func (c *InspectorClient) Dispose() {
 	C.DeleteInspectorClient(c.ptr)
+}
+
+func handleConsoleAPIMessageCallback(callbackRef C.int, data unsafe.Pointer) {
+	// Convert data to Go data
+	// client := clientRegistry.get(callbackRef)
+	// client.handleConsoleAPIMessageCallback(data)
 }

--- a/inspector.go
+++ b/inspector.go
@@ -7,6 +7,8 @@ import (
 	"unicode/utf16"
 )
 
+// Represents the level of console output from JavaScript. E.g., `console.log`,
+// `console.error`, etc.
 type MessageErrorLevel uint8
 
 const (
@@ -18,15 +20,30 @@ const (
 	ErrorLevelAll = ErrorLevelLog | ErrorLevelDebug | ErrorLevelInfo | ErrorLevelError | ErrorLevelWarning
 )
 
+// An Inspector in v8 provides access to internals of the engine, such as
+// console output
+//
+// To receive console output, you need to first create an [InspectorClient]
+// which will handle the interaction for a specific [Context].
+//
+// After a Context is created, you need to register it with the Inspector using
+// [Inspector.ContextCreated], and cleanup using [Inspector.ContextDestroyed].
+//
+// See also: https://v8.github.io/api/head/classv8__inspector_1_1V8Inspector.html
 type Inspector struct {
 	ptr C.InspectorPtr
 }
 
+// An InspectorClient is the bridge from the [Inspector] to your code.
 type InspectorClient struct {
 	ptr          C.InspectorClientPtr
 	clientHandle cgo.Handle
 }
 
+// ConsoleAPIMessage contains the information from v8 from console function
+// calls.
+//
+// V8 also provides a stack trace, which isn't yet supported here.
 type ConsoleAPIMessage struct {
 	contextGroupId int
 	ErrorLevel     MessageErrorLevel
@@ -37,16 +54,16 @@ type ConsoleAPIMessage struct {
 	// stackTrace StackTrace
 }
 
+// A ConsoleAPIMessageHandler will receive JavaScript `console` API calls.
 type ConsoleAPIMessageHandler interface {
 	ConsoleAPIMessage(message ConsoleAPIMessage)
 }
 
-type ConsoleAPIMessageHandlerFunc func(msg ConsoleAPIMessage)
-
-func (f ConsoleAPIMessageHandlerFunc) ConsoleAPIMessage(msg ConsoleAPIMessage) {
-	f(msg)
-}
-
+// NewInspector creates an [Inspector] for a specific [Isolate] iso
+// communicating with the [InspectorClient] client.
+//
+// Before disposing the iso, be sure to dispose the inspector using
+// [Inspector.Dispose]
 func NewInspector(iso *Isolate, client *InspectorClient) *Inspector {
 	ptr := C.CreateInspector(iso.ptr, client.ptr)
 	return &Inspector{
@@ -54,18 +71,25 @@ func NewInspector(iso *Isolate, client *InspectorClient) *Inspector {
 	}
 }
 
+// Dispose the [Inspector]. Call this before disposing the [Isolate] and the
+// [InspectorClient] that this is connected to.
 func (i *Inspector) Dispose() {
 	C.DeleteInspector(i.ptr)
 }
 
+// ContextCreated tells the inspector that a new [Context] has been created.
+// This must be called before the [InspectorClient] can be used.
 func (i *Inspector) ContextCreated(ctx *Context) {
 	C.InspectorContextCreated(i.ptr, ctx.ptr)
 }
 
+// ContextDestroyed must be called before a [Context] is closed.
 func (i *Inspector) ContextDestroyed(ctx *Context) {
 	C.InspectorContextDestroyed(i.ptr, ctx.ptr)
 }
 
+// Create a new [InspectorClient] passing a handler that will receive the
+// callbacks from v8.
 func NewInspectorClient(handler ConsoleAPIMessageHandler) *InspectorClient {
 	clientHandle := cgo.NewHandle(handler)
 	ptr := C.NewInspectorClient(C.uintptr_t(clientHandle))
@@ -75,7 +99,10 @@ func NewInspectorClient(handler ConsoleAPIMessageHandler) *InspectorClient {
 	}
 }
 
+// Dispose frees up resources taken up by the [InspectorClient]. Be sure to call
+// this after calling [Inspector.Dispose]
 func (c *InspectorClient) Dispose() {
+	c.clientHandle.Delete()
 	C.DeleteInspectorClient(c.ptr)
 }
 
@@ -93,7 +120,6 @@ func stringViewToString(d C.StringViewData) string {
 	}
 }
 
-//
 //export goHandleConsoleAPIMessageCallback
 func goHandleConsoleAPIMessageCallback(
 	callbackRef C.uintptr_t,
@@ -104,16 +130,16 @@ func goHandleConsoleAPIMessageCallback(
 	lineNumber C.uint,
 	columnNumber C.uint,
 ) {
-	// Convert data to Go data
 	handle := cgo.Handle(callbackRef)
 	if client, ok := handle.Value().(ConsoleAPIMessageHandler); ok {
 		// TODO, Stack trace
 		client.ConsoleAPIMessage(ConsoleAPIMessage{
-			ErrorLevel:   MessageErrorLevel(errorLevel),
-			Message:      stringViewToString(message),
-			Url:          stringViewToString(url),
-			LineNumber:   uint(lineNumber),
-			ColumnNumber: uint(columnNumber),
+			contextGroupId: int(contextGroupId),
+			ErrorLevel:     MessageErrorLevel(errorLevel),
+			Message:        stringViewToString(message),
+			Url:            stringViewToString(url),
+			LineNumber:     uint(lineNumber),
+			ColumnNumber:   uint(columnNumber),
 		})
 	}
 }

--- a/inspector.go
+++ b/inspector.go
@@ -1,0 +1,32 @@
+package v8go
+
+// #include "inspector.h"
+import "C"
+
+type Inspector struct {
+	ptr C.InspectorPtr
+}
+
+type InspectorClient struct {
+	ptr C.InspectorClientPtr
+}
+
+func NewInspector(iso *Isolate, client *InspectorClient) *Inspector {
+	ptr := C.CreateInspector(iso.ptr, client.ptr)
+	return &Inspector{
+		ptr: ptr,
+	}
+}
+
+func (i *Inspector) Dispose() {
+	C.DeleteInspector(i.ptr)
+}
+
+func NewInspectorClient() *InspectorClient {
+	ptr := C.NewInspectorClient()
+	return &InspectorClient{ptr: ptr}
+}
+
+func (c *InspectorClient) Dispose() {
+	C.DeleteInspectorClient(c.ptr)
+}

--- a/inspector.go
+++ b/inspector.go
@@ -141,6 +141,10 @@ func stringViewToString(d C.StringViewData) string {
 	}
 }
 
+// goHandleConsoleAPIMessageCallback is called by C code when a console message
+// is written. The correct [InspectorClient] is retrieved by the cgoHandle,
+// which is a [cgo.Handle].
+//
 //export goHandleConsoleAPIMessageCallback
 func goHandleConsoleAPIMessageCallback(
 	cgoHandle C.uintptr_t,

--- a/inspector.go
+++ b/inspector.go
@@ -65,7 +65,12 @@ type InspectorClient struct {
 // ConsoleAPIMessage contains the information from v8 from console function
 // calls.
 //
-// V8 also provides a stack trace, which isn't yet supported here.
+// The fields correspond to the arguments for the C++ function
+// v8_inspector::InspectorClient::consoleAPIMessage
+//
+// Note: Stack traces are not supported.
+//
+// See also: https://v8.github.io/api/head/classv8__inspector_1_1V8InspectorClient.html
 type ConsoleAPIMessage struct {
 	contextGroupId int
 	ErrorLevel     MessageErrorLevel

--- a/inspector.go
+++ b/inspector.go
@@ -3,7 +3,6 @@ package v8go
 // #include "inspector.h"
 import "C"
 import (
-	"fmt"
 	"sync"
 	"unicode/utf16"
 )
@@ -100,7 +99,6 @@ func (i *Inspector) Dispose() {
 }
 
 func (i *Inspector) ContextCreated(ctx *Context) {
-	fmt.Println("Created from Go")
 	C.InspectorContextCreated(i.ptr, ctx.ptr)
 }
 
@@ -143,7 +141,6 @@ func goHandleConsoleAPIMessageCallback(
 	errorLevel C.int,
 	message C.StringViewData,
 ) {
-	fmt.Println("Callback from Go")
 	// Convert data to Go data
 	client := clientRegistry.get(callbackRef)
 	client.handler.ConsoleAPIMessage(ConsoleAPIMessage{

--- a/inspector.go
+++ b/inspector.go
@@ -31,12 +31,12 @@ const (
 //
 // See also: https://v8.github.io/api/head/classv8__inspector_1_1V8Inspector.html
 type Inspector struct {
-	ptr C.InspectorPtr
+	ptr *C.v8Inspector
 }
 
 // An InspectorClient is the bridge from the [Inspector] to your code.
 type InspectorClient struct {
-	ptr          C.InspectorClientPtr
+	ptr          *C.v8InspectorClient
 	clientHandle cgo.Handle
 }
 

--- a/inspector.go
+++ b/inspector.go
@@ -71,7 +71,6 @@ type ConsoleAPIMessage struct {
 	Url            string
 	LineNumber     uint
 	ColumnNumber   uint
-	// stackTrace StackTrace
 }
 
 // A ConsoleAPIMessageHandler will receive JavaScript `console` API calls.

--- a/inspector.go
+++ b/inspector.go
@@ -9,6 +9,8 @@ import (
 
 // Represents the level of console output from JavaScript. E.g., `console.log`,
 // `console.error`, etc.
+//
+// The values reflect the values of v8::Isolate::MessageErrorLevel
 type MessageErrorLevel uint8
 
 const (

--- a/inspector.go
+++ b/inspector.go
@@ -12,6 +12,8 @@ import (
 // `console.error`, etc.
 //
 // The values reflect the values of v8::Isolate::MessageErrorLevel
+//
+// See also: https://v8.github.io/api/head/classv8_1_1Isolate.html
 type MessageErrorLevel uint8
 
 func (lvl MessageErrorLevel) String() string {

--- a/inspector.go
+++ b/inspector.go
@@ -4,6 +4,7 @@ package v8go
 import "C"
 import (
 	"runtime/cgo"
+	"strconv"
 	"unicode/utf16"
 )
 
@@ -12,6 +13,23 @@ import (
 //
 // The values reflect the values of v8::Isolate::MessageErrorLevel
 type MessageErrorLevel uint8
+
+func (lvl MessageErrorLevel) String() string {
+	switch lvl {
+	case ErrorLevelLog:
+		return "log"
+	case ErrorLevelDebug:
+		return "debug"
+	case ErrorLevelError:
+		return "error"
+	case ErrorLevelInfo:
+		return "info"
+	case ErrorLevelWarning:
+		return "warning"
+	default:
+		return strconv.Itoa(int(lvl))
+	}
+}
 
 const (
 	ErrorLevelLog MessageErrorLevel = 1 << iota

--- a/inspector.go
+++ b/inspector.go
@@ -71,9 +71,9 @@ type ConsoleAPIMessage struct {
 	contextGroupId int
 	ErrorLevel     MessageErrorLevel
 	Message        string
-	url            string
-	lineNumber     int
-	columnNumber   int
+	Url            string
+	LineNumber     uint
+	ColumnNumber   uint
 	// stackTrace StackTrace
 }
 
@@ -140,12 +140,19 @@ func goHandleConsoleAPIMessageCallback(
 	contextGroupId C.int,
 	errorLevel C.int,
 	message C.StringViewData,
+	url C.StringViewData,
+	lineNumber C.uint,
+	columnNumber C.uint,
 ) {
 	// Convert data to Go data
 	client := clientRegistry.get(callbackRef)
+	// TODO, Stack trace
 	client.handler.ConsoleAPIMessage(ConsoleAPIMessage{
-		Message:    stringViewToString(message),
-		ErrorLevel: MessageErrorLevel(errorLevel),
+		ErrorLevel:   MessageErrorLevel(errorLevel),
+		Message:      stringViewToString(message),
+		Url:          stringViewToString(url),
+		LineNumber:   uint(lineNumber),
+		ColumnNumber: uint(columnNumber),
 	})
 	// client.handleConsoleAPIMessageCallback(data)
 }

--- a/inspector.h
+++ b/inspector.h
@@ -13,16 +13,13 @@ class V8InspectorClient;
 };  // namespace v8_inspector
 
 typedef v8::Isolate v8Isolate;
-typedef v8_inspector::V8Inspector* InspectorPtr;
-typedef v8_inspector::V8InspectorClient* InspectorClientPtr;
+typedef v8_inspector::V8Inspector v8Inspector;
+typedef v8_inspector::V8InspectorClient v8InspectorClient;
 
 extern "C" {
 #else
 typedef struct v8Inspector v8Inspector;
-typedef v8Inspector* InspectorPtr;
-
 typedef struct v8InspectorClient v8InspectorClient;
-typedef v8InspectorClient* InspectorClientPtr;
 
 typedef struct v8Isolate v8Isolate;
 
@@ -36,14 +33,14 @@ typedef _Bool bool;
 typedef struct m_ctx m_ctx;
 typedef m_ctx* ContextPtr;
 
-extern InspectorPtr CreateInspector(v8Isolate* iso, InspectorClientPtr client);
-extern void DeleteInspector(InspectorPtr inspector);
-extern void InspectorContextCreated(InspectorPtr inspector, ContextPtr context);
-extern void InspectorContextDestroyed(InspectorPtr inspector,
+extern v8Inspector* CreateInspector(v8Isolate* iso, v8InspectorClient* client);
+extern void DeleteInspector(v8Inspector* inspector);
+extern void InspectorContextCreated(v8Inspector* inspector, ContextPtr context);
+extern void InspectorContextDestroyed(v8Inspector* inspector,
                                       ContextPtr context);
 
-extern InspectorClientPtr NewInspectorClient(uintptr_t callbackRef);
-extern void DeleteInspectorClient(InspectorClientPtr client);
+extern v8InspectorClient* NewInspectorClient(uintptr_t callbackRef);
+extern void DeleteInspectorClient(v8InspectorClient* client);
 
 typedef struct StringViewData {
   bool is8bit;

--- a/inspector.h
+++ b/inspector.h
@@ -1,0 +1,43 @@
+#ifndef V8GO_INSPECTOR_H
+#define V8GO_INSPECTOR_H
+
+#ifdef __cplusplus
+
+namespace v8 {
+class Isolate;
+};
+
+namespace v8_inspector {
+class V8Inspector;
+class V8InspectorClient;
+};  // namespace v8_inspector
+
+typedef v8::Isolate v8Isolate;
+typedef v8_inspector::V8Inspector* InspectorPtr;
+typedef v8_inspector::V8InspectorClient* InspectorClientPtr;
+
+extern "C" {
+#else
+typedef struct v8Inspector v8Inspector;
+typedef v8Inspector* InspectorPtr;
+
+typedef struct v8InspectorClient v8InspectorClient;
+typedef v8InspectorClient* InspectorClientPtr;
+
+typedef struct v8Isolate v8Isolate;
+
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+extern InspectorPtr CreateInspector(v8Isolate* iso, InspectorClientPtr client);
+extern void DeleteInspector(InspectorPtr inspector);
+extern InspectorClientPtr NewInspectorClient();
+extern void DeleteInspectorClient(InspectorClientPtr client);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif

--- a/inspector.h
+++ b/inspector.h
@@ -31,13 +31,11 @@ typedef _Bool bool;
 #include <stdint.h>
 
 typedef struct m_ctx m_ctx;
-typedef m_ctx* ContextPtr;
 
 extern v8Inspector* CreateInspector(v8Isolate* iso, v8InspectorClient* client);
 extern void DeleteInspector(v8Inspector* inspector);
-extern void InspectorContextCreated(v8Inspector* inspector, ContextPtr context);
-extern void InspectorContextDestroyed(v8Inspector* inspector,
-                                      ContextPtr context);
+extern void InspectorContextCreated(v8Inspector* inspector, m_ctx* context);
+extern void InspectorContextDestroyed(v8Inspector* inspector, m_ctx* context);
 
 extern v8InspectorClient* NewInspectorClient(uintptr_t callbackRef);
 extern void DeleteInspectorClient(v8InspectorClient* client);

--- a/inspector.h
+++ b/inspector.h
@@ -33,7 +33,7 @@ typedef struct v8Isolate v8Isolate;
 
 extern InspectorPtr CreateInspector(v8Isolate* iso, InspectorClientPtr client);
 extern void DeleteInspector(InspectorPtr inspector);
-extern InspectorClientPtr NewInspectorClient();
+extern InspectorClientPtr NewInspectorClient(int callbackRef);
 extern void DeleteInspectorClient(InspectorClientPtr client);
 
 #ifdef __cplusplus

--- a/inspector.h
+++ b/inspector.h
@@ -31,8 +31,15 @@ typedef struct v8Isolate v8Isolate;
 #include <stddef.h>
 #include <stdint.h>
 
+typedef struct m_ctx m_ctx;
+typedef m_ctx* ContextPtr;
+
 extern InspectorPtr CreateInspector(v8Isolate* iso, InspectorClientPtr client);
 extern void DeleteInspector(InspectorPtr inspector);
+extern void InspectorContextCreated(InspectorPtr inspector, ContextPtr context);
+extern void InspectorContextDestroyed(InspectorPtr inspector,
+                                      ContextPtr context);
+
 extern InspectorClientPtr NewInspectorClient(int callbackRef);
 extern void DeleteInspectorClient(InspectorClientPtr client);
 

--- a/inspector.h
+++ b/inspector.h
@@ -26,6 +26,8 @@ typedef v8InspectorClient* InspectorClientPtr;
 
 typedef struct v8Isolate v8Isolate;
 
+typedef _Bool bool;
+
 #endif
 
 #include <stddef.h>
@@ -42,6 +44,12 @@ extern void InspectorContextDestroyed(InspectorPtr inspector,
 
 extern InspectorClientPtr NewInspectorClient(int callbackRef);
 extern void DeleteInspectorClient(InspectorClientPtr client);
+
+typedef struct StringViewData {
+  bool is8bit;
+  void const* data;
+  int length;
+} StringViewData;
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/inspector.h
+++ b/inspector.h
@@ -42,7 +42,7 @@ extern void InspectorContextCreated(InspectorPtr inspector, ContextPtr context);
 extern void InspectorContextDestroyed(InspectorPtr inspector,
                                       ContextPtr context);
 
-extern InspectorClientPtr NewInspectorClient(int callbackRef);
+extern InspectorClientPtr NewInspectorClient(uintptr_t callbackRef);
 extern void DeleteInspectorClient(InspectorClientPtr client);
 
 typedef struct StringViewData {

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -6,11 +6,20 @@ import (
 	v8 "github.com/tommie/v8go"
 )
 
+type consoleAPIMessageRecorder struct {
+	messages []v8.ConsoleAPIMessage
+}
+
+func (r *consoleAPIMessageRecorder) ConsoleAPIMessage(msg v8.ConsoleAPIMessage) {
+	r.messages = append(r.messages, msg)
+}
+
 func TestMonitorCreateDispose(t *testing.T) {
+	recorder := consoleAPIMessageRecorder{}
 	t.Parallel()
 	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	client := v8.NewInspectorClient()
+	client := v8.NewInspectorClient(&recorder)
 	defer client.Dispose()
 	inspector := v8.NewInspector(iso, client)
 	defer inspector.Dispose()

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -23,4 +23,18 @@ func TestMonitorCreateDispose(t *testing.T) {
 	defer client.Dispose()
 	inspector := v8.NewInspector(iso, client)
 	defer inspector.Dispose()
+	context := v8.NewContext(iso)
+	defer context.Close()
+	inspector.ContextCreated(context)
+	defer inspector.ContextDestroyed(context)
+	_, err := context.RunScript("console.log('Hello, world!')", "")
+	if err != nil {
+		t.Error("Error occurred: " + err.Error())
+		return
+	}
+	if len(recorder.messages) != 1 {
+		t.Error("Expected exactly one message")
+	} else if recorder.messages[0].Message != "Hello, world!" {
+		t.Error("Expected Hello, World")
+	}
 }

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -27,14 +27,27 @@ func TestMonitorCreateDispose(t *testing.T) {
 	defer context.Close()
 	inspector.ContextCreated(context)
 	defer inspector.ContextDestroyed(context)
-	_, err := context.RunScript("console.log('Hello, world!')", "")
+	_, err := context.RunScript("console.log('Hello, world!'); console.error('Error, world!');", "")
 	if err != nil {
 		t.Error("Error occurred: " + err.Error())
 		return
 	}
-	if len(recorder.messages) != 1 {
+	if len(recorder.messages) != 2 {
 		t.Error("Expected exactly one message")
-	} else if recorder.messages[0].Message != "Hello, world!" {
-		t.Error("Expected Hello, World")
+	} else {
+		msg1 := recorder.messages[0]
+		msg2 := recorder.messages[1]
+		if msg1.ErrorLevel != v8.ErrorLevelLog {
+			t.Errorf("Expected Log error level. Got %d", msg1.ErrorLevel)
+		}
+		if msg2.ErrorLevel != v8.ErrorLevelError {
+			t.Errorf("Expected Error error level. Got: %d", msg2.ErrorLevel)
+		}
+		if msg1.Message != "Hello, world!" {
+			t.Errorf("Expected Hello, World, got %s", msg1.Message)
+		}
+		if msg2.Message != "Error, world!" {
+			t.Errorf("Expected Error, world!, got %s", msg2.Message)
+		}
 	}
 }

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -1,0 +1,17 @@
+package v8go_test
+
+import (
+	"testing"
+
+	v8 "github.com/tommie/v8go"
+)
+
+func TestMonitorCreateDispose(t *testing.T) {
+	t.Parallel()
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+	client := v8.NewInspectorClient()
+	defer client.Dispose()
+	inspector := v8.NewInspector(iso, client)
+	defer inspector.Dispose()
+}


### PR DESCRIPTION
This adds the ability to get `console` messages to Go, but to do that you need to tap into the "inspector", which is also AFAIK the entry point to controlling the debugger. I just need the console messages. Although it seems that I can also use it to control time; which would be useful for my purpose.

This is still WIP, functionally close to done (for my needs), but I'd appreciate feedback, and opinion on code structure.

I also intend to add code-doc before merging.

**Inheriting from InspectorClient**

In C++, you must create a class inheriting from `InspectorClient`. This must then be installed using `Inspector::Create`, and you need to manually attach to each v8 context.

The `InspectorClient` has all virtual functions, and the client code overrides the ones they care about.

My idea was to create a Go interface for each capability. The user can choose to implement the functions they care about.

So far, I only care about console messages, so that's what I have now. It it still lacking stack traces, but should be simple enough.

When registering an inspector, you need a name, and a contextGroupId. I have no idea what they are used for, except contextGroupId must be <> 0, otherwise nothing happens. Right now they are hardcoded in C++ code.

That also means that I don't know if it makes sense to control from Go code or not.

The client itself does not seem to be related to an isolate. I don't know if it's valid to use the same client for multiple isolates. The code seems to indicate it's possible.

**Utility types**

The code uses a `StringView` type for strings. In reality; they're always utf16le (i.e. no byte order mark). Nothing is documented, so all is from experimenting, and only on one platform, my M2 mac. Btw, there must be a better way of converting `[]byte` to `[]uint16`, but I didn't find anything. Btw, I will add a test case that uses some weird unicode characters that take up more than one element in utf16. I did test that manually, and it did work, but better have it in the tests.


I created a more generic type for registering "callbacks". Just like the `Isolate` registers function callbacks, which I think should just be replaced with that type; which should be moved somewhere else.

**Package name**

If we follow the idea to create a separate interface for each capability that the inspector supports, it will be quite a lot of types, not necessarily with a sensible name of their own without some context. Prefixing them with `InspectorClient` makes them even longer, they're long enough IMHO.

I was wondering if it would make sense to put it in a sub-package, `v8go/inspector`. The C++ code does have it's own namespace, `v8_inspector`.

p.s. it's only now I see that I have reformatted `function_template.go`. I have just opened and saved it