### PR TITLE
Fix instructions for leak check on macOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ with leak checking enabled, since it isn't enabled by default on macOS. E.g. wit
 installation of llvm, the tests can be run with
 
 ```
-CXX=/usr/local/opt/llvm/bin/clang++ CC=/usr/local/opt/llvm/bin/clang go test -c --tags leakcheck -ldflags=-compressdwarf=false
+CXX=$HOMEBREW_PREFIX/opt/llvm/bin/clang++ CC=$HOMEBREW_PREFIX/opt/llvm/bin/clang go test -c --tags leakcheck -ldflags=-compressdwarf=false
 ASAN_OPTIONS=detect_leaks=1 ./v8go.test
 ```
 


### PR DESCRIPTION
It's been a while, but I wanted to "complete" my changes, and also automate memory-leak checking.

The instructions for running on macOS was outdated, as homebrew uses a different root folder now, so I've updated the instructions.

Unfortunately, running this locally results a non-zero exit code, which is unfortunate, as there's a github workflow for checking leaks.

```
SUMMARY: AddressSanitizer: 10544 byte(s) leaked in 56 allocation(s).
```

I deliberately also deliberately pushed code that _should_ leak to a test PR in my own space (it creates a `cgo.Handle` that it doesn't delete). But the build didn't catch this.

Anyway, this PR is just about updating the readme file. Understanding the output of the leak check is a little outside my area of expertise.