### PR TITLE
Implement FunctionTemplate.InstanceTemplate

### DIFF
--- a/function_template.cc
+++ b/function_template.cc
@@ -101,3 +101,13 @@ m_template* FunctionTemplateInstanceTemplate(m_template* ptr) {
 
   return ot;
 }
+
+m_template* FunctionTemplatePrototypeTemplate(m_template* ptr) {
+  LOCAL_TEMPLATE(ptr);
+  Local<FunctionTemplate> fn_tmpl = tmpl.As<FunctionTemplate>();
+  m_template* ot = new m_template;
+  ot->iso = iso;
+  ot->ptr.Reset(iso, fn_tmpl->PrototypeTemplate());
+
+  return ot;
+}

--- a/function_template.cc
+++ b/function_template.cc
@@ -91,3 +91,13 @@ RtnValue FunctionTemplateGetFunction(m_template* ptr, m_ctx* ctx) {
   rtn.value = tracked_value(ctx, val);
   return rtn;
 }
+
+m_template* FunctionTemplateInstanceTemplate(m_template* ptr) {
+  LOCAL_TEMPLATE(ptr);
+  Local<FunctionTemplate> fn_tmpl = tmpl.As<FunctionTemplate>();
+  m_template* ot = new m_template;
+  ot->iso = iso;
+  ot->ptr.Reset(iso, fn_tmpl->InstanceTemplate());
+
+  return ot;
+}

--- a/function_template.go
+++ b/function_template.go
@@ -60,6 +60,13 @@ func (i *FunctionCallbackInfo) Release() {
 // FunctionTemplate is used to create functions at runtime.
 // There can only be one function created from a FunctionTemplate in a context.
 // The lifetime of the created function is equal to the lifetime of the context.
+//
+// A FunctionTemplate can be used to create "constructors", and add methods to
+// the "class". [FunctionTemplate.PrototypeTemplate] can be used to add normal
+// methods on the class, and [FunctionTemplate.InstanceTemplate] can be used to
+// add fields automatically to new instances of a class.
+//
+// V8 API Docs: https://v8.github.io/api/head/classv8_1_1FunctionTemplate.html
 type FunctionTemplate struct {
 	*template
 }
@@ -113,10 +120,19 @@ func (tmpl *FunctionTemplate) GetFunction(ctx *Context) *Function {
 // InstanceTemplate gets the [ObjectTemplate] that is used for new object
 // instances created when this function is used as a constructor.
 //
-// Any values created on this will be [own properties] on the instance, not the
-// prototype.
+// You can add functions and values to new instance using [ObjectTemplate.Set]
+// and [ObjectTemplate.SetSymbol]. Those values will become [own properties] on
+// the instance, not the prototype.
 //
-// See also: https://v8.github.io/api/head/classv8_1_1FunctionTemplate.html
+// Adding a function to an instance template corresponds to the following
+// JavaScript:
+//
+//	class Example() {
+//		constructor() {
+//			this.foo = function() { /* creates a function on the instance */ }
+//		}
+//	}
+//
 // [own properties]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
 func (tmpl *FunctionTemplate) InstanceTemplate() *ObjectTemplate {
 	result := &template{
@@ -127,6 +143,27 @@ func (tmpl *FunctionTemplate) InstanceTemplate() *ObjectTemplate {
 	return &ObjectTemplate{result}
 }
 
+// PrototypeTemplate gets the [ObjectTemplate] that is used to create the
+// prototype object associated with the function.
+//
+// You can call [ObjectTemplate.Set] or [ObjectTemplate.SetSymbol], passing a
+// [FunctionTemplate] to add a "method" to the class.
+//
+// Adding a function to a prototype template corresponds normal method on a
+// JavaScript "class":
+//
+//	class Example {
+//		foo() { /* this is a method on the prototype */ }
+//	}
+//
+// Or the old-school way
+//
+//	function Example() {}
+//	Example.prototype.foo = function() { }
+//
+// The function becomes an [own property] on the prototype, not the instance.
+//
+// [own property]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
 func (tmpl *FunctionTemplate) PrototypeTemplate() *ObjectTemplate {
 	result := &template{
 		ptr: C.FunctionTemplatePrototypeTemplate(tmpl.ptr),

--- a/function_template.go
+++ b/function_template.go
@@ -110,6 +110,23 @@ func (tmpl *FunctionTemplate) GetFunction(ctx *Context) *Function {
 	return &Function{val}
 }
 
+// InstanceTemplate gets the [ObjectTemplate] that is used for new object
+// instances created when this function is used as a constructor.
+//
+// Any values created on this will be [own properties] on the instance, not the
+// prototype.
+//
+// See also: https://v8.github.io/api/head/classv8_1_1FunctionTemplate.html
+// [own properties]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
+func (tmpl *FunctionTemplate) InstanceTemplate() *ObjectTemplate {
+	result := &template{
+		ptr: C.FunctionTemplateInstanceTemplate(tmpl.ptr),
+		iso: tmpl.iso,
+	}
+	runtime.SetFinalizer(result, (*template).finalizer)
+	return &ObjectTemplate{result}
+}
+
 // Note that ideally `thisAndArgs` would be split into two separate arguments, but they were combined
 // to workaround an ERROR_COMMITMENT_LIMIT error on windows that was detected in CI.
 //

--- a/function_template.go
+++ b/function_template.go
@@ -127,6 +127,15 @@ func (tmpl *FunctionTemplate) InstanceTemplate() *ObjectTemplate {
 	return &ObjectTemplate{result}
 }
 
+func (tmpl *FunctionTemplate) PrototypeTemplate() *ObjectTemplate {
+	result := &template{
+		ptr: C.FunctionTemplatePrototypeTemplate(tmpl.ptr),
+		iso: tmpl.iso,
+	}
+	runtime.SetFinalizer(result, (*template).finalizer)
+	return &ObjectTemplate{result}
+}
+
 // Note that ideally `thisAndArgs` would be split into two separate arguments, but they were combined
 // to workaround an ERROR_COMMITMENT_LIMIT error on windows that was detected in CI.
 //

--- a/function_template.go
+++ b/function_template.go
@@ -133,7 +133,7 @@ func (tmpl *FunctionTemplate) GetFunction(ctx *Context) *Function {
 //		}
 //	}
 //
-// [own properties]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
+// [own properties]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties
 func (tmpl *FunctionTemplate) InstanceTemplate() *ObjectTemplate {
 	result := &template{
 		ptr: C.FunctionTemplateInstanceTemplate(tmpl.ptr),
@@ -163,7 +163,7 @@ func (tmpl *FunctionTemplate) InstanceTemplate() *ObjectTemplate {
 //
 // The function becomes an [own property] on the prototype, not the instance.
 //
-// [own property]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
+// [own property]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties
 func (tmpl *FunctionTemplate) PrototypeTemplate() *ObjectTemplate {
 	result := &template{
 		ptr: C.FunctionTemplatePrototypeTemplate(tmpl.ptr),

--- a/function_template.h
+++ b/function_template.h
@@ -23,6 +23,7 @@ typedef struct m_ctx m_ctx;
 
 extern m_template* NewFunctionTemplate(v8Isolate* iso_ptr, int callback_ref);
 extern RtnValue FunctionTemplateGetFunction(m_template* ptr, m_ctx* ctx_ptr);
+extern m_template* FunctionTemplateInstanceTemplate(m_template* ptr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/function_template.h
+++ b/function_template.h
@@ -24,6 +24,7 @@ typedef struct m_ctx m_ctx;
 extern m_template* NewFunctionTemplate(v8Isolate* iso_ptr, int callback_ref);
 extern RtnValue FunctionTemplateGetFunction(m_template* ptr, m_ctx* ctx_ptr);
 extern m_template* FunctionTemplateInstanceTemplate(m_template* ptr);
+extern m_template* FunctionTemplatePrototypeTemplate(m_template* ptr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -249,6 +249,49 @@ func TestFunctionTemplate_instance_template(t *testing.T) {
 	}
 }
 
+func TestFunctionTemplate_prototype_template(t *testing.T) {
+	t.Parallel()
+
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+
+	constructor := v8.NewFunctionTemplate(iso,
+		// This works as a constructor, so we don't need to return any values.
+		func(info *v8.FunctionCallbackInfo) *v8.Value { return nil })
+	constructor.PrototypeTemplate().
+		Set("getBar", v8.NewFunctionTemplateWithError(iso,
+			func(info *v8.FunctionCallbackInfo) (*v8.Value, error) {
+				return v8.NewValue(iso, "Bar")
+			}))
+	global := v8.NewObjectTemplate(iso)
+	global.Set("Foo", constructor)
+
+	ctx := v8.NewContext(iso, global)
+	defer ctx.Close()
+
+	val, err := ctx.RunScript("const foo = new Foo(); foo.getBar()", "")
+	if err != nil || val == nil {
+		t.Fatal("Script error", err)
+	}
+	if val.String() != "Bar" {
+		t.Fatalf("Unexpected value. Expected 'Bar'. Got: '%s'", val.String())
+	}
+
+	// The prototype has _two_ own properties, constructor and getBar. Filter out
+	// the constructor (don't want an implementation detail of the ordering to
+	// break the test)
+	val, err = ctx.RunScript(`
+		Object.getOwnPropertyNames(Foo.prototype)
+			.filter(x => x!='constructor')
+			.join(', ')`, "")
+	if err != nil || val == nil {
+		t.Fatal("Script error", err)
+	}
+	if val.String() != "getBar" {
+		t.Fatalf("Unexpected value. Expected 'getBar'. Got: '%s'", val.String())
+	}
+}
+
 func ExampleFunctionTemplate() {
 	iso := v8.NewIsolate()
 	defer iso.Dispose()

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -240,12 +240,20 @@ func TestFunctionTemplate_instance_template(t *testing.T) {
 	}
 
 	// The function is an "own property" of the instance, and the only one
-	val, err = ctx.RunScript(`Object.getOwnPropertyNames(foo).join(",")`, "")
+	val, err = ctx.RunScript(`[
+		Object.getOwnPropertyNames(foo).includes("getBar"),
+		Object.getOwnPropertyNames(Foo.prototype).includes("getBar"),
+	].join(", ")`, "")
+
 	if err != nil || val == nil {
 		t.Fatal("Script error", err)
 	}
-	if val.String() != "getBar" {
-		t.Errorf("Unexpected value. Expected 'getBar'. Got: '%s'", val.String())
+	if val.String() != "true, false" {
+		t.Errorf(`Unexpected value.
+	[own property of instance, own property of prototype]
+	Expected 'true, false'. Got: '%s'`,
+			val.String(),
+		)
 	}
 }
 
@@ -277,18 +285,19 @@ func TestFunctionTemplate_prototype_template(t *testing.T) {
 		t.Fatalf("Unexpected value. Expected 'Bar'. Got: '%s'", val.String())
 	}
 
-	// The prototype has _two_ own properties, constructor and getBar. Filter out
-	// the constructor (don't want an implementation detail of the ordering to
-	// break the test)
-	val, err = ctx.RunScript(`
-		Object.getOwnPropertyNames(Foo.prototype)
-			.filter(x => x!='constructor')
-			.join(', ')`, "")
+	val, err = ctx.RunScript(`[
+		Object.getOwnPropertyNames(foo).includes("getBar"),
+		Object.getOwnPropertyNames(Foo.prototype).includes("getBar"),
+	].join(", ")`, "")
 	if err != nil || val == nil {
 		t.Fatal("Script error", err)
 	}
-	if val.String() != "getBar" {
-		t.Fatalf("Unexpected value. Expected 'getBar'. Got: '%s'", val.String())
+	if val.String() != "false, true" {
+		t.Errorf(`Unexpected value.
+	[own property of instance, own property of prototype]
+	Expected 'false, true'. Got: '%s'`,
+			val.String(),
+		)
 	}
 }
 


### PR DESCRIPTION
Adds the ability to set InstanceTemplate and ObjectTemplate, necessary when building the prototype from Go code