### PR TITLE
Add support for ObjectTemplate::SetAccessorProperty

### DIFF
--- a/object_template.cc
+++ b/object_template.cc
@@ -64,14 +64,6 @@ void ObjectTemplateSetAccessorProperty(TemplatePtr ptr,
                                        int attributes) {
   LOCAL_TEMPLATE(ptr);
 
-  /*
-   *
-  Isolate* iso = tmpl_ptr->iso;      \
-  Locker locker(iso);                \
-  Isolate::Scope isolate_scope(iso); \
-  HandleScope handle_scope(iso);     \
-  Local<Template> tmpl = tmpl_ptr->ptr.Get(iso);
-   */
   Local<String> key_val =
       String::NewFromUtf8(iso, key, NewStringType::kNormal).ToLocalChecked();
   Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();

--- a/object_template.cc
+++ b/object_template.cc
@@ -56,3 +56,32 @@ int ObjectTemplateInternalFieldCount(TemplatePtr ptr) {
   Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();
   return obj_tmpl->InternalFieldCount();
 }
+
+void ObjectTemplateSetAccessorProperty(TemplatePtr ptr,
+                                       const char* key,
+                                       TemplatePtr get,
+                                       TemplatePtr set,
+                                       int attributes) {
+  LOCAL_TEMPLATE(ptr);
+
+  /*
+   *
+  Isolate* iso = tmpl_ptr->iso;      \
+  Locker locker(iso);                \
+  Isolate::Scope isolate_scope(iso); \
+  HandleScope handle_scope(iso);     \
+  Local<Template> tmpl = tmpl_ptr->ptr.Get(iso);
+   */
+  Local<String> key_val =
+      String::NewFromUtf8(iso, key, NewStringType::kNormal).ToLocalChecked();
+  Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();
+  Local<FunctionTemplate> get_tmpl =
+      get ? get->ptr.Get(iso).As<FunctionTemplate>()
+          : Local<FunctionTemplate>();
+  Local<FunctionTemplate> set_tmpl =
+      set ? set->ptr.Get(iso).As<FunctionTemplate>()
+          : Local<FunctionTemplate>();
+
+  return obj_tmpl->SetAccessorProperty(key_val, get_tmpl, set_tmpl,
+                                       (PropertyAttribute)attributes);
+}

--- a/object_template.go
+++ b/object_template.go
@@ -67,6 +67,19 @@ func (o *ObjectTemplate) SetInternalFieldCount(fieldCount uint32) {
 	C.ObjectTemplateSetInternalFieldCount(o.ptr, C.int(fieldCount))
 }
 
+// SetAccessorProperty creates a named accessor property, i.e., a property that
+// is implemented as a function call. Arguments get and set represents the
+// getter and setter, and can both be nil.
+//
+// Note: The [ReadOnly] should not be used with a readonly property. If set is
+// nil, the property will be readonly, and passing [None] is a sensible default.
+//
+// Normally, you don't need to keep a reference to the function template, i.e.,
+// the same function object is not used multiple places. The function
+// [ObjectTemplate.SetAccessorPropertyCallback] provides a simpler interface for
+// this case.
+//
+// This corresponds to ObjectTemplate::SetAccessorProperty in the C++ API.
 func (o *ObjectTemplate) SetAccessorProperty(
 	key string,
 	get *FunctionTemplate,
@@ -88,9 +101,14 @@ func (o *ObjectTemplate) SetAccessorProperty(
 	C.ObjectTemplateSetAccessorProperty(o.ptr, ckey, getter, setter, C.int(attributes))
 }
 
-// SetAccessorPropertyCallback is a simplified version of SetAccessorProperty
-// that automatically create the [FunctionTemplate] for the callbacks when the
-// caller doesn't need the template(s).
+// SetAccessorPropertyCallback creates an accessor property, i.e., a property
+// that is accessed through a get and a set function.
+//
+// This function calls [ObjectTemplate.SetAccessorProperty], see the
+// documentation for that function for further documentation.
+// SetAccessorPropertyCallback provides a simpler interface for the most common
+// use case when you don't need to keep a reference to the get and set
+// functions.
 func (o *ObjectTemplate) SetAccessorPropertyCallback(
 	key string,
 	get FunctionCallbackWithError,

--- a/object_template.go
+++ b/object_template.go
@@ -74,11 +74,6 @@ func (o *ObjectTemplate) SetInternalFieldCount(fieldCount uint32) {
 // Note: The [ReadOnly] should not be used with a readonly property. If set is
 // nil, the property will be readonly, and passing [None] is a sensible default.
 //
-// Normally, you don't need to keep a reference to the function template, i.e.,
-// the same function object is not used multiple places. The function
-// [ObjectTemplate.SetAccessorPropertyCallback] provides a simpler interface for
-// this case.
-//
 // This corresponds to ObjectTemplate::SetAccessorProperty in the C++ API.
 func (o *ObjectTemplate) SetAccessorProperty(
 	key string,
@@ -99,33 +94,6 @@ func (o *ObjectTemplate) SetAccessorProperty(
 		setter = set.ptr
 	}
 	C.ObjectTemplateSetAccessorProperty(o.ptr, ckey, getter, setter, C.int(attributes))
-}
-
-// SetAccessorPropertyCallback creates an accessor property, i.e., a property
-// that is accessed through a get and a set function.
-//
-// This function calls [ObjectTemplate.SetAccessorProperty], see the
-// documentation for that function for further documentation.
-// SetAccessorPropertyCallback provides a simpler interface for the most common
-// use case when you don't need to keep a reference to the get and set
-// functions.
-func (o *ObjectTemplate) SetAccessorPropertyCallback(
-	key string,
-	get FunctionCallbackWithError,
-	set FunctionCallbackWithError,
-	attributes PropertyAttribute,
-) {
-	var (
-		getter *FunctionTemplate
-		setter *FunctionTemplate
-	)
-	if get != nil {
-		getter = NewFunctionTemplateWithError(o.iso, get)
-	}
-	if set != nil {
-		setter = NewFunctionTemplateWithError(o.iso, set)
-	}
-	o.SetAccessorProperty(key, getter, setter, attributes)
 }
 
 // InternalFieldCount returns the number of internal fields that instances of this

--- a/object_template.h
+++ b/object_template.h
@@ -27,6 +27,11 @@ extern RtnValue ObjectTemplateNewInstance(m_template* ptr, m_ctx* ctx_ptr);
 extern void ObjectTemplateSetInternalFieldCount(m_template* ptr,
                                                 int field_count);
 extern int ObjectTemplateInternalFieldCount(m_template* ptr);
+extern void ObjectTemplateSetAccessorProperty(m_template* ptr,
+                                              const char* key,
+                                              m_template* get,
+                                              m_template* set,
+                                              int attributes);
 
 #ifdef __cplusplus
 }

--- a/object_template_helper_example_test.go
+++ b/object_template_helper_example_test.go
@@ -1,0 +1,72 @@
+package v8go_test
+
+import (
+	"fmt"
+
+	v8 "github.com/tommie/v8go"
+)
+
+// SetObjectTemplateAccessorProperty shows an example of a helper that client
+// code could optionally introduce.
+//
+// ObjectTemplate.SetAccessorProperty requires FunctionTemplate instances as
+// arguments, but you rarely need the actual function template outside the
+// scope of setting an accessor property.
+//
+// If many accessor properties must be created, this example could reduce
+// repetitive trivial code.
+func SetObjectTemplateAccessorProperty(
+	iso *v8.Isolate,
+	templ *v8.ObjectTemplate,
+	key string,
+	get v8.FunctionCallbackWithError,
+	set v8.FunctionCallbackWithError,
+	attributes v8.PropertyAttribute,
+) {
+	var (
+		v8get *v8.FunctionTemplate
+		v8set *v8.FunctionTemplate
+	)
+	if get != nil {
+		v8get = v8.NewFunctionTemplateWithError(iso, get)
+	}
+	if set != nil {
+		v8set = v8.NewFunctionTemplateWithError(iso, set)
+	}
+	templ.SetAccessorProperty(key, v8get, v8set, attributes)
+}
+
+func ExampleObjectTemplate_SetAccessorProperty_Helpers() {
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+	tmpl := v8.NewObjectTemplate(iso)
+
+	current, _ := v8.NewValue(iso, "current")
+	SetObjectTemplateAccessorProperty(iso, tmpl,
+		"prop",
+		// Getter
+		func(*v8.FunctionCallbackInfo) (*v8.Value, error) {
+			return current, nil
+		},
+		func(info *v8.FunctionCallbackInfo) (*v8.Value, error) {
+			current = info.Args()[0]
+			return nil, nil
+		},
+		v8.None,
+	)
+
+	global := v8.NewObjectTemplate(iso)
+	global.Set("obj", tmpl)
+	ctx := v8.NewContext(iso, global)
+	defer ctx.Close()
+
+	value, _ := ctx.RunScript("obj.prop", "")
+	fmt.Printf("Property value before set: %s\n", value.String())
+
+	value, _ = ctx.RunScript("obj.prop = 'new value'; obj.prop", "")
+	fmt.Printf("Property value after set: %s\n", value.String())
+
+	// Output:
+	// Property value before set: current
+	// Property value after set: new value
+}

--- a/object_template_helper_example_test.go
+++ b/object_template_helper_example_test.go
@@ -36,7 +36,7 @@ func SetObjectTemplateAccessorProperty(
 	templ.SetAccessorProperty(key, v8get, v8set, attributes)
 }
 
-func ExampleObjectTemplate_SetAccessorProperty_Helpers() {
+func ExampleObjectTemplate_SetAccessorProperty_helpers() {
 	iso := v8.NewIsolate()
 	defer iso.Dispose()
 	tmpl := v8.NewObjectTemplate(iso)
@@ -48,6 +48,7 @@ func ExampleObjectTemplate_SetAccessorProperty_Helpers() {
 		func(*v8.FunctionCallbackInfo) (*v8.Value, error) {
 			return current, nil
 		},
+		// Setter
 		func(info *v8.FunctionCallbackInfo) (*v8.Value, error) {
 			current = info.Args()[0]
 			return nil, nil

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -273,29 +273,3 @@ func ExampleObjectTemplate_SetAccessorProperty() {
 	// Output:
 	// Property value: Value
 }
-
-func ExampleObjectTemplate_SetAccessorPropertyCallback() {
-	iso := v8.NewIsolate()
-	defer iso.Dispose()
-	get := v8.NewFunctionTemplateWithError(iso,
-		func(*v8.FunctionCallbackInfo) (*v8.Value, error) { // Getter
-			return v8.NewValue(iso, "Value")
-		},
-	)
-	tmpl := v8.NewObjectTemplate(iso)
-	tmpl.SetAccessorProperty("prop",
-		get,
-		nil, // Setter
-		v8.None,
-	)
-
-	global := v8.NewObjectTemplate(iso)
-	global.Set("obj", tmpl)
-	ctx := v8.NewContext(iso, global)
-	defer ctx.Close()
-
-	value, _ := ctx.RunScript("obj.prop", "")
-	fmt.Printf("Property value: %s\n", value.String())
-	// Output:
-	// Property value: Value
-}

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -163,16 +163,17 @@ func TestObjectTemplateNewInstance(t *testing.T) {
 	}
 }
 
-func TestObjectTemplateSetAccessorProperty_ReadOnly(t *testing.T) {
+func TestObjectTemplateSetAccessorProperty_OnlyGetter(t *testing.T) {
 	// Create an accessor property that has only a getter.
 	// Setting the value from JS should not have a side effects
 	t.Parallel()
 	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	tmpl := v8.NewObjectTemplate(iso)
+
 	get := v8.NewFunctionTemplateWithError(iso,
 		func(*v8.FunctionCallbackInfo) (*v8.Value, error) { return v8.NewValue(iso, "Value") },
 	)
+	tmpl := v8.NewObjectTemplate(iso)
 	tmpl.SetAccessorProperty("prop", get, nil, v8.None)
 
 	global := v8.NewObjectTemplate(iso)
@@ -194,19 +195,20 @@ func TestObjectTemplateSetAccessorProperty_ReadOnly(t *testing.T) {
 	}
 }
 
-func TestObjectTemplateSetAccessorProperty_ReadWrite(t *testing.T) {
+func TestObjectTemplateSetAccessorProperty_GetterAnSetter(t *testing.T) {
 	t.Parallel()
 	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	tmpl := v8.NewObjectTemplate(iso)
 	var value *v8.Value
-	var get = v8.NewFunctionTemplateWithError(iso, func(*v8.FunctionCallbackInfo) (*v8.Value, error) {
-		return value, nil
+
+	var get = v8.NewFunctionTemplate(iso, func(*v8.FunctionCallbackInfo) *v8.Value {
+		return value
 	})
-	var set = v8.NewFunctionTemplateWithError(iso, func(i *v8.FunctionCallbackInfo) (*v8.Value, error) {
-		value = i.Args()[0] // A property settor will always have _one_ argument
-		return nil, nil
+	var set = v8.NewFunctionTemplate(iso, func(i *v8.FunctionCallbackInfo) *v8.Value {
+		value = i.Args()[0] // A property setter will always have _one_ argument
+		return nil
 	})
+	tmpl := v8.NewObjectTemplate(iso)
 	tmpl.SetAccessorProperty("prop", get, set, v8.None)
 
 	global := v8.NewObjectTemplate(iso)

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -165,7 +165,7 @@ func TestObjectTemplateNewInstance(t *testing.T) {
 
 func TestObjectTemplateSetAccessorProperty_OnlyGetter(t *testing.T) {
 	// Create an accessor property that has only a getter.
-	// Setting the value from JS should not have a side effects
+	// Setting the value from JS should not have side effects.
 	t.Parallel()
 	iso := v8.NewIsolate()
 	defer iso.Dispose()
@@ -205,7 +205,7 @@ func TestObjectTemplateSetAccessorProperty_GetterAnSetter(t *testing.T) {
 		return value
 	})
 	var set = v8.NewFunctionTemplate(iso, func(i *v8.FunctionCallbackInfo) *v8.Value {
-		value = i.Args()[0] // A property setter will always have _one_ argument
+		value = i.Args()[0] // A property setter will always have _one_ argument.
 		return nil
 	})
 	tmpl := v8.NewObjectTemplate(iso)


### PR DESCRIPTION
Finally wrote some tests for this baby :) 

There's thing in the interface I'm unsure of. I expose the basic `SetAccessorProperty` which requires `FunctionTemplate` instances as input.

But mostly, you don't need this instance. That would only be if you actually use the same function object in multiple places, but that's not the normal usage pattern.

So I also created a helper on top, `SetAccessorPropertyCallback`, which creates the templates. I'm unsure if this should be in the interface. I find it helpful, but I have no objection to remove it.

Regarding the flags, I haven't researched what they do. I discovered, you shouldn't use `ReadOnly`. I _think_ the only flag that is applicable for this case is `DontEnum`, which I believe would prevent the property from being iterated in `for . in` loops. But it's still listed by `Object.getOwnPropertyNames`. But I didn't validate this, so I didn't add to the documentation.