### PR TITLE
Add support for ObjectTemplate.MarkAsUndetectable

### DIFF
--- a/function_template.cc
+++ b/function_template.cc
@@ -8,7 +8,7 @@
 
 using namespace v8;
 
-void FunctionTemplateCallback(const FunctionCallbackInfo<Value>& info) {
+void FunctionTemplateCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
   Isolate* iso = info.GetIsolate();
   ISOLATE_SCOPE(iso);
 

--- a/function_template.cc
+++ b/function_template.cc
@@ -8,7 +8,7 @@
 
 using namespace v8;
 
-void FunctionTemplateCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+void FunctionTemplateCallback(const FunctionCallbackInfo<Value>& info) {
   Isolate* iso = info.GetIsolate();
   ISOLATE_SCOPE(iso);
 

--- a/function_template.h
+++ b/function_template.h
@@ -7,7 +7,10 @@
 
 namespace v8 {
 class Isolate;
+template <class F> class FunctionCallbackInfo;
 }
+
+void FunctionTemplateCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
 
 typedef v8::Isolate v8Isolate;
 

--- a/function_template.h
+++ b/function_template.h
@@ -7,8 +7,9 @@
 
 namespace v8 {
 class Isolate;
-template <class F> class FunctionCallbackInfo;
-}
+template <class F>
+class FunctionCallbackInfo;
+}  // namespace v8
 
 void FunctionTemplateCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
 

--- a/inspector.cc
+++ b/inspector.cc
@@ -8,9 +8,9 @@ using namespace v8;
 using namespace v8_inspector;
 
 /**
- * InspectorClient is an implementation of v8_inspector::V8InspectorClient that is
- * designed to be able to call back to Go code to a specific instance identified
- * by a cgo handle.
+ * InspectorClient is an implementation of v8_inspector::V8InspectorClient that
+ * is designed to be able to call back to Go code to a specific instance
+ * identified by a cgo handle.
  *
  * See also: https://pkg.go.dev/runtime/cgo#Handle
  */

--- a/object_template.cc
+++ b/object_template.cc
@@ -50,6 +50,13 @@ void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr, int field_count) {
   obj_tmpl->SetInternalFieldCount(field_count);
 }
 
+void ObjectTemplateMarkAsUndetectable(TemplatePtr ptr) {
+  LOCAL_TEMPLATE(ptr);
+
+  Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();
+  obj_tmpl->MarkAsUndetectable();
+}
+
 int ObjectTemplateInternalFieldCount(TemplatePtr ptr) {
   LOCAL_TEMPLATE(ptr);
 

--- a/object_template.cc
+++ b/object_template.cc
@@ -4,6 +4,7 @@
 #include "deps/include/v8-isolate.h"
 #include "deps/include/v8-locker.h"
 #include "deps/include/v8-template.h"
+#include "function_template.h"
 #include "template-macros.h"
 
 using namespace v8;
@@ -83,4 +84,13 @@ void ObjectTemplateSetAccessorProperty(TemplatePtr ptr,
 
   return obj_tmpl->SetAccessorProperty(key_val, get_tmpl, set_tmpl,
                                        (PropertyAttribute)attributes);
+}
+
+void ObjectTemplateSetCallAsFunctionHandler(TemplatePtr ptr, int callback_ref) {
+  LOCAL_TEMPLATE(ptr);
+
+  Local<Integer> cbData = Integer::New(iso, callback_ref);
+
+  Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();
+  obj_tmpl->SetCallAsFunctionHandler(FunctionTemplateCallback, cbData);
 }

--- a/object_template.go
+++ b/object_template.go
@@ -107,10 +107,10 @@ func (o *ObjectTemplate) apply(opts *contextOptions) {
 }
 
 // MarkAsUndetectable marks object instances of the template as undetectable. Undetectable
-// objects behave like `undefined`, but you can access properties defined on undetectable
+// objects behave like undefined, but you can access properties defined on undetectable
 // objects.
 //
-// Note: Undetectable objects MUST have a `CallAsFunctionHandler`, see
+// Note: Undetectable objects MUST have a CallAsFunctionHandler, see
 // [ObjectTemplate.SetCallAsFunctionHandler]
 func (o *ObjectTemplate) MarkAsUndetectable() {
 	C.ObjectTemplateMarkAsUndetectable(o.ptr)

--- a/object_template.go
+++ b/object_template.go
@@ -109,3 +109,14 @@ func (o *ObjectTemplate) apply(opts *contextOptions) {
 func (o *ObjectTemplate) MarkAsUndetectable() {
 	C.ObjectTemplateMarkAsUndetectable(o.ptr)
 }
+
+func (o *ObjectTemplate) SetCallAsFunctionHandler(callback FunctionCallbackWithError) {
+	if callback == nil {
+		panic("nil FunctionCallback argument not supported")
+	}
+	cbref := o.iso.registerCallback(callback)
+	C.ObjectTemplateSetCallAsFunctionHandler(
+		o.ptr,
+		C.int(cbref),
+	)
+}

--- a/object_template.go
+++ b/object_template.go
@@ -106,10 +106,19 @@ func (o *ObjectTemplate) apply(opts *contextOptions) {
 	opts.gTmpl = o
 }
 
+// Mark object instances of the template as undetectable. Undetectable objects
+// behave like undefined, but you can access properties defined on undetectable
+// objects.
+//
+// Note: Undetectable objects MUST have a CallAsFunctionHandler, see
+// [ObjectTemplate.SetCallAsFunctionHandler]
 func (o *ObjectTemplate) MarkAsUndetectable() {
 	C.ObjectTemplateMarkAsUndetectable(o.ptr)
 }
 
+// Sets the callback to be used when calling instances created from this template
+// as a function. If no callback is set, instances behave like normal JavaScript
+// objects that cannot be called as a function.
 func (o *ObjectTemplate) SetCallAsFunctionHandler(callback FunctionCallbackWithError) {
 	if callback == nil {
 		panic("nil FunctionCallback argument not supported")

--- a/object_template.go
+++ b/object_template.go
@@ -105,3 +105,7 @@ func (o *ObjectTemplate) InternalFieldCount() uint32 {
 func (o *ObjectTemplate) apply(opts *contextOptions) {
 	opts.gTmpl = o
 }
+
+func (o *ObjectTemplate) MarkAsUndetectable() {
+	C.ObjectTemplateMarkAsUndetectable(o.ptr)
+}

--- a/object_template.go
+++ b/object_template.go
@@ -106,22 +106,22 @@ func (o *ObjectTemplate) apply(opts *contextOptions) {
 	opts.gTmpl = o
 }
 
-// Mark object instances of the template as undetectable. Undetectable objects
-// behave like undefined, but you can access properties defined on undetectable
+// MarkAsUndetectable marks object instances of the template as undetectable. Undetectable
+// objects behave like `undefined`, but you can access properties defined on undetectable
 // objects.
 //
-// Note: Undetectable objects MUST have a CallAsFunctionHandler, see
+// Note: Undetectable objects MUST have a `CallAsFunctionHandler`, see
 // [ObjectTemplate.SetCallAsFunctionHandler]
 func (o *ObjectTemplate) MarkAsUndetectable() {
 	C.ObjectTemplateMarkAsUndetectable(o.ptr)
 }
 
-// Sets the callback to be used when calling instances created from this template
-// as a function. If no callback is set, instances behave like normal JavaScript
+// SetCallAsFunctionHandler sets the callback to be used when calling instances created
+// from this template. If no callback is set, instances behave like normal JavaScript
 // objects that cannot be called as a function.
 func (o *ObjectTemplate) SetCallAsFunctionHandler(callback FunctionCallbackWithError) {
 	if callback == nil {
-		panic("nil FunctionCallback argument not supported")
+		panic("nil callback argument not supported")
 	}
 	cbref := o.iso.registerCallback(callback)
 	C.ObjectTemplateSetCallAsFunctionHandler(

--- a/object_template.h
+++ b/object_template.h
@@ -32,6 +32,7 @@ extern void ObjectTemplateSetAccessorProperty(m_template* ptr,
                                               m_template* get,
                                               m_template* set,
                                               int attributes);
+extern void ObjectTemplateMarkAsUndetectable(m_template* ptr);
 
 #ifdef __cplusplus
 }

--- a/object_template.h
+++ b/object_template.h
@@ -33,6 +33,7 @@ extern void ObjectTemplateSetAccessorProperty(m_template* ptr,
                                               m_template* set,
                                               int attributes);
 extern void ObjectTemplateMarkAsUndetectable(m_template* ptr);
+extern void ObjectTemplateSetCallAsFunctionHandler(m_template* ptr, int callback_ref);
 
 #ifdef __cplusplus
 }

--- a/object_template.h
+++ b/object_template.h
@@ -33,7 +33,8 @@ extern void ObjectTemplateSetAccessorProperty(m_template* ptr,
                                               m_template* set,
                                               int attributes);
 extern void ObjectTemplateMarkAsUndetectable(m_template* ptr);
-extern void ObjectTemplateSetCallAsFunctionHandler(m_template* ptr, int callback_ref);
+extern void ObjectTemplateSetCallAsFunctionHandler(m_template* ptr,
+                                                   int callback_ref);
 
 #ifdef __cplusplus
 }

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -383,7 +383,7 @@ func TestObjectTemplateMarkAsUndetectableOnInstanceTemplate(t *testing.T) {
 		}
 	}
 
-	res, err = ctx.RunScript("if (undetectable) { true; } else { false; }", "")
+	res, err = ctx.RunScript("Boolean(undetectable)", "")
 	if err != nil {
 		t.Errorf("Error calling typeof undetectable: %v", err)
 	} else {

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -5,7 +5,6 @@
 package v8go_test
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 	"runtime"
@@ -358,30 +357,42 @@ func TestObjectTemplateMarkAsUndetectableOnInstanceTemplate(t *testing.T) {
 		SetCallAsFunctionHandler(func(info *v8.FunctionCallbackInfo) (*v8.Value, error) {
 			return info.This().Value, nil
 		})
-	instance, err0 := desc.InstanceTemplate().NewInstance(ctx)
+	instance, err := desc.InstanceTemplate().NewInstance(ctx)
+	if err != nil {
+		t.Fatalf("Error creating instance: %v", err)
+	}
 	ctx.Global().Set("undetectable", instance)
 
-	res, err1 := ctx.RunScript("undetectable.toString()", "")
-	if res.String() != "[object Object]" {
-		t.Errorf(
-			`Error running "undetectable.toString()". Expected "[object Object]", got: %s`,
-			res.String(),
-		)
-	}
-	res, err2 := ctx.RunScript("typeof undetectable", "")
-	if res.String() != "undefined" {
-		t.Errorf(
-			`Error running "typeof undetectable". Expected "undefined", got: %s`,
-			res.String(),
-		)
+	res, err := ctx.RunScript("undetectable.toString()", "")
+	if err != nil {
+		t.Errorf("Error calling toString(): %v", err)
+	} else {
+		if res.String() != "[object Object]" {
+			t.Errorf(
+				`Error running "undetectable.toString()". Expected "[object Object]", got: %s`,
+				res.String(),
+			)
+		}
 	}
 
-	res, err3 := ctx.RunScript("if (undetectable) { true; } else { false; }", "")
-	if res.Boolean() {
-		t.Errorf("Expected undetectable object to be falsy")
+	res, err = ctx.RunScript("typeof undetectable", "")
+	if err != nil {
+		t.Errorf("Error calling typeof undetectable: %v", err)
+	} else {
+		if res.String() != "undefined" {
+			t.Errorf(
+				`Error running "typeof undetectable". Expected "undefined", got: %s`,
+				res.String(),
+			)
+		}
 	}
 
-	if err := errors.Join(err0, err1, err2, err3); err != nil {
-		t.Errorf("Error occurred: %v", err)
+	res, err = ctx.RunScript("if (undetectable) { true; } else { false; }", "")
+	if err != nil {
+		t.Errorf("Error calling typeof undetectable: %v", err)
+	} else {
+		if res.Boolean() {
+			t.Errorf("Expected undetectable object to be falsy")
+		}
 	}
 }

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -28,10 +28,9 @@ func TestObjectTemplate(t *testing.T) {
 
 	val, _ := v8.NewValue(iso, "bar")
 	objVal := v8.NewObjectTemplate(iso)
-	bigbigint, _ := new(
-		big.Int,
-	).SetString("36893488147419099136", 10)
+
 	// larger than a single word size (64bit)
+	bigbigint, _ := new(big.Int).SetString("36893488147419099136", 10)
 	bigbignegint, _ := new(big.Int).SetString("-36893488147419099136", 10)
 
 	tests := [...]struct {

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -5,6 +5,7 @@
 package v8go_test
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"runtime"
@@ -342,29 +343,47 @@ func TestObjectTemplateMarkAsUndetectable(t *testing.T) {
 	}
 }
 
-/*
-  v8::HandleScope scope(env->GetIsolate());
+func TestObjectTemplateMarkAsUndetectableOnInstanceTemplate(t *testing.T) {
+	t.Parallel()
 
-  Local<v8::FunctionTemplate> desc =
-      v8::FunctionTemplate::New(env->GetIsolate());
-  desc->InstanceTemplate()->MarkAsUndetectable();  // undetectable
-  desc->InstanceTemplate()->SetCallAsFunctionHandler(ReturnThis);  // callable
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+	ctx := v8.NewContext(iso)
+	defer ctx.Close()
 
-  Local<v8::Object> obj = desc->GetFunction(env.local())
-                              .ToLocalChecked()
-                              ->NewInstance(env.local())
-                              .ToLocalChecked();
+	desc := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		return nil
+	})
+	desc.InstanceTemplate().MarkAsUndetectable()
+	desc.InstanceTemplate().
+		SetCallAsFunctionHandler(func(info *v8.FunctionCallbackInfo) (*v8.Value, error) {
+			return info.This().Value, nil
+		})
+	instance, err0 := desc.InstanceTemplate().NewInstance(ctx)
+	ctx.Global().Set("undetectable", instance)
 
-  CHECK(obj->IsUndetectable());
+	res, err1 := ctx.RunScript("undetectable.toString()", "")
+	if res.String() != "[object Object]" {
+		t.Errorf(
+			`Error running "undetectable.toString()". Expected "[object Object]", got: %s`,
+			res.String(),
+		)
+	}
+	res, err2 := ctx.RunScript("typeof undetectable", "")
+	if res.String() != "undefined" {
+		t.Errorf(
+			`Error running "typeof undetectable". Expected "undefined", got: %s`,
+			res.String(),
+		)
+	}
 
-  CHECK(
-      env->Global()->Set(env.local(), v8_str("undetectable"), obj).FromJust());
+	res, err3 := ctx.RunScript("if (undetectable) { true; } else { false; }", "")
+	if res.Boolean() {
+		t.Errorf("Expected undetectable object to be falsy")
+	}
 
-  ExpectString("undetectable.toString()", "[object Object]");
-  ExpectString("typeof undetectable", "undefined");
-  ExpectString("typeof(undetectable)", "undefined");
-  ExpectBoolean("typeof undetectable == 'undefined'", true);
-  ExpectBoolean("typeof undetectable == 'object'", false);
-  ExpectBoolean("if (undetectable) { true; } else { false; }", false);
-  ExpectBoolean("!undetectable", true);
-*/
+	if err := errors.Join(err0, err1, err2, err3); err != nil {
+		t.Errorf("Error occurred: %v", err)
+	}
+
+}

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -278,10 +278,6 @@ func TestObjectTemplateSetCallAsFunctionHandler(t *testing.T) {
 	iso := v8.NewIsolate()
 	defer iso.Dispose()
 	tmpl := v8.NewObjectTemplate(iso)
-	if _, err := tmpl.NewInstance(nil); err == nil {
-		t.Error("expected error but got <nil>")
-	}
-
 	ctx := v8.NewContext(iso)
 	defer ctx.Close()
 
@@ -307,10 +303,10 @@ func TestObjectTemplateMarkAsUndetectable(t *testing.T) {
 	iso := v8.NewIsolate()
 	defer iso.Dispose()
 	obj := v8.NewObjectTemplate(iso)
-	obj.MarkAsUndetectable()
 	obj.SetCallAsFunctionHandler(func(info *v8.FunctionCallbackInfo) (*v8.Value, error) {
 		return info.This().Value, nil
 	})
+	obj.MarkAsUndetectable()
 	ctx := v8.NewContext(iso)
 	defer ctx.Close()
 	v, err := v8.NewValue(iso, "42")

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -385,5 +385,4 @@ func TestObjectTemplateMarkAsUndetectableOnInstanceTemplate(t *testing.T) {
 	if err := errors.Join(err0, err1, err2, err3); err != nil {
 		t.Errorf("Error occurred: %v", err)
 	}
-
 }

--- a/v8go.cc
+++ b/v8go.cc
@@ -15,10 +15,9 @@
 #include "template-macros.h"
 #include "template.h"
 #include "value-macros.h"
+#include "function_template.h"
 
 using namespace v8;
-
-void FunctionTemplateCallback(const FunctionCallbackInfo<Value>& info);
 
 const int ScriptCompilerNoCompileOptions = ScriptCompiler::kNoCompileOptions;
 const int ScriptCompilerConsumeCodeCache = ScriptCompiler::kConsumeCodeCache;

--- a/v8go.cc
+++ b/v8go.cc
@@ -11,11 +11,11 @@
 #include "utils.h"
 
 #include "context-macros.h"
+#include "function_template.h"
 #include "isolate-macros.h"
 #include "template-macros.h"
 #include "template.h"
 #include "value-macros.h"
-#include "function_template.h"
 
 using namespace v8;
 


### PR DESCRIPTION
Addresses #94 

Documentation is a brief copy of C++ documentation, but while testing, I noticed odd behavior.

Calling `MarkAsUndetectable()` on an a plain `ObjectTemplate` caused a seg fault. 

But following the C++ example, it used an instance template from a function template, and then using `functionTemplate.InstanceTemplate()`, and that did make the test pass.

But the C++ documentation doesn't indicate that this is only valid on instance templates, making me unsure if it should be documented.