### PR TITLE
Implement Value.ToString()

### DIFF
--- a/errors.cc
+++ b/errors.cc
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <sstream>
 
 #include "deps/include/v8-exception.h"
@@ -47,4 +48,16 @@ RtnError ExceptionError(TryCatch& try_catch, Isolate* iso, Local<Context> ctx) {
   }
 
   return rtn;
+}
+
+void ErrorRelease(RtnError err) {
+  if (err.msg) {
+    free((void*)err.msg);
+  }
+  if (err.location) {
+    free((void*)err.location);
+  }
+  if (err.stack) {
+    free((void*)err.stack);
+  }
 }

--- a/errors.h
+++ b/errors.h
@@ -43,6 +43,8 @@ typedef struct {
   RtnError error;
 } RtnValue;
 
+void ErrorRelease(RtnError err);
+
 #ifdef __cplusplus
 }
 #endif

--- a/value.cc
+++ b/value.cc
@@ -1,6 +1,9 @@
 #include "value.h"
+#include <stdlib.h>
 #include "context.h"
 #include "deps/include/v8-context.h"
+#include "deps/include/v8-exception.h"
+#include "errors.h"
 #include "isolate-macros.h"
 #include "utils.h"
 #include "value-macros.h"
@@ -10,6 +13,29 @@
   m_ctx* ctx = isolateInternalContext(iso);
 
 using namespace v8;
+
+RtnString StringToRtnString(v8::Isolate* iso, Local<String> val) {
+  RtnString res = {};
+  res.length = val->Utf8LengthV2(iso);
+  res.data = static_cast<char*>(malloc(res.length));
+  val->WriteUtf8V2(iso, (char*)res.data, res.length);
+  return res;
+}
+
+RtnString ExceptionToRtnString(TryCatch& try_catch,
+                               v8::Isolate* iso,
+                               Local<Context> ctx) {
+  RtnString res = {};
+  res.error = ExceptionError(try_catch, iso, ctx);
+  return res;
+}
+
+void RtnStringRelease(RtnString rtnString) {
+  if (rtnString.data) {
+    free((void*)rtnString.data);
+  }
+  ErrorRelease(rtnString.error);
+}
 
 void ValueRelease(ValuePtr ptr) {
   if (ptr == nullptr) {
@@ -223,16 +249,11 @@ double ValueToNumber(ValuePtr ptr) {
 
 RtnString ValueToDetailString(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
-  RtnString rtn = {0};
   Local<String> str;
   if (!value->ToDetailString(local_ctx).ToLocal(&str)) {
-    rtn.error = ExceptionError(try_catch, iso, local_ctx);
-    return rtn;
+    return ExceptionToRtnString(try_catch, iso, local_ctx);
   }
-  String::Utf8Value ds(iso, str);
-  rtn.data = CopyString(ds);
-  rtn.length = ds.length();
-  return rtn;
+  return StringToRtnString(iso, str);
 }
 
 RtnString ValueToString(ValuePtr ptr) {
@@ -564,4 +585,10 @@ int ValueIsWasmModuleObject(ValuePtr ptr) {
 int ValueIsModuleNamespaceObject(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   return value->IsModuleNamespaceObject();
+}
+
+RtnString ValueTypeOf(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  Local<String> result = value->TypeOf(iso);
+  return StringToRtnString(iso, result);
 }

--- a/value.go
+++ b/value.go
@@ -240,8 +240,8 @@ func (v *Value) Object() *Object {
 // are returned as-is, objects will return `[object Object]` and functions will
 // print their definition.
 func (v *Value) String() string {
-	s := C.ValueToString(v.ptr)
-	defer C.free(unsafe.Pointer(s.data))
+	var s C.RtnString = C.ValueToString(v.ptr)
+	defer C.RtnStringRelease(s)
 	return C.GoStringN(s.data, C.int(s.length))
 }
 
@@ -613,4 +613,10 @@ func (v *Value) SharedArrayBufferGetContents() ([]byte, func(), error) {
 	byte_slice := unsafe.Slice(byte_ptr, byte_size)
 
 	return byte_slice, release, nil
+}
+
+func (v *Value) TypeOf() string {
+	var s C.RtnString = C.ValueTypeOf(v.ptr)
+	defer C.RtnStringRelease(s)
+	return C.GoStringN(s.data, C.int(s.length))
 }

--- a/value.h
+++ b/value.h
@@ -53,7 +53,9 @@ typedef struct {
 } RtnString;
 
 void ValueRelease(ValuePtr ptr);
+void RtnStringRelease(RtnString rtnString);
 extern RtnString ValueToString(ValuePtr ptr);
+extern RtnString ValueTypeOf(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);
 int ValueToBoolean(ValuePtr ptr);
 int32_t ValueToInt32(ValuePtr ptr);
@@ -163,5 +165,6 @@ extern BackingStorePtr SharedArrayBufferGetBackingStore(ValuePtr ptr);
 
 #ifdef __cplusplus
 }
+
 #endif
 #endif

--- a/value_test.go
+++ b/value_test.go
@@ -427,7 +427,10 @@ func TestValueBigInt(t *testing.T) {
 	iso := v8.NewIsolate()
 	defer iso.Dispose()
 
-	x, _ := new(big.Int).SetString("36893488147419099136", 10) // larger than a single word size (64bit)
+	x, _ := new(
+		big.Int,
+	).SetString("36893488147419099136", 10)
+	// larger than a single word size (64bit)
 
 	tests := [...]struct {
 		source   string
@@ -697,7 +700,10 @@ func TestValueIsXXX(t *testing.T) {
 				t.Fatalf("failed to run script: %v", err)
 			}
 			if !tt.assert(val) {
-				t.Errorf("value is false for %s", runtime.FuncForPC(reflect.ValueOf(tt.assert).Pointer()).Name())
+				t.Errorf(
+					"value is false for %s",
+					runtime.FuncForPC(reflect.ValueOf(tt.assert).Pointer()).Name(),
+				)
 			}
 		})
 	}
@@ -814,6 +820,36 @@ func TestValueArrayBufferContents(t *testing.T) {
 	}
 	_, _, err = val.SharedArrayBufferGetContents()
 	if err == nil {
-		t.Fatalf("Expected an error trying call SharedArrayBufferGetContents on value of incorrect type")
+		t.Fatalf(
+			"Expected an error trying call SharedArrayBufferGetContents on value of incorrect type",
+		)
+	}
+}
+
+func TestValueTypeOf(t *testing.T) {
+	t.Parallel()
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+	ctx := v8.NewContext(iso)
+	defer ctx.Close()
+
+	str1, _ := v8.NewValue(iso, "String")
+	if got := str1.TypeOf(); got != "string" {
+		t.Errorf(`NewValue("String"): expected string, got %s`, got)
+	}
+
+	str2, _ := ctx.RunScript("'string'", "")
+	if got := str2.TypeOf(); got != "string" {
+		t.Errorf("TypeOf('string'): expected string, got %s", got)
+	}
+
+	num1, _ := v8.NewValue(iso, 0.01)
+	if got := num1.TypeOf(); got != "number" {
+		t.Errorf(`NewValue(0.01): expected number, got %s`, got)
+	}
+
+	num2, _ := ctx.RunScript("0.01", "")
+	if got := num2.TypeOf(); got != "number" {
+		t.Errorf("TypeOf(0.01): expected number, got %s", got)
 	}
 }


### PR DESCRIPTION
I mostly wanted to have `Value.TypeOf()` to help inspecting values returned when implementing ESM - but so I could just as well implement it as a separate PR.

I did some refactor to move cleanup code to the C-side.

On the go side, I changed the `:=` declare and assign to `var` with explicit types for how it reads, as I find it becomes more obvious on the next line that the cleanup code corresponds to the value.

But I also created cleanup helpers for this, as well as the Error type.

```
	var s C.RtnString = C.ValueToString(v.ptr)
	defer C.RtnStringRelease(s)
```

I also created some helper functions to convert both an error and a `Local<String>` to this value, but I actually thought that this type was used in more places. Turns out that there are only two, as the `ValueToString` doesn't actually use a `Local<String>`.

But some of the logic has more reuse potential because the type here is for the case where there is _both_ a string and error value returned. There are more places where it's just a string value returned and no error, so the general conversion of a `Local<string>` to `size_t/char*` pair can be used in more places. E.g., I have some in my ESM branch, so I might make a refactor PR on this alone to simplify transfering `Local<String>` to go code.