### PR TITLE
Add support for "external" values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for "External" values, using cgo handles referencing internal values. This is a more Go friendly alternative where in V8, they are designed to contain C++ pointers.
+
 ### Changed
 
 ## [v0.33.0] - 2025-05-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for "External" values, using cgo handles referencing internal values. This is a more Go friendly alternative where in V8, they are designed to contain C++ pointers.
+
 ### Changed
 
 ## [v0.34.0] - 2025-10-07

--- a/example_new_value_external_handle_test.go
+++ b/example_new_value_external_handle_test.go
@@ -1,0 +1,106 @@
+package v8go_test
+
+import (
+	"fmt"
+	"runtime/cgo"
+
+	v8 "github.com/tommie/v8go"
+)
+
+type Calculator struct {
+	stack []int32
+}
+
+func (c *Calculator) Peek() int32 {
+	l := len(c.stack)
+	if l > 0 {
+		return c.stack[l-1]
+	} else {
+		return 0
+	}
+}
+func (c *Calculator) Push(v int32) { c.stack = append(c.stack, v) }
+func (c *Calculator) Add() {
+	l := len(c.stack)
+	if l < 2 {
+		panic("Not enough elements")
+	}
+	a := c.stack[l-1]
+	b := c.stack[l-2]
+	c.stack[l-2] = a + b
+	c.stack = c.stack[0 : l-1]
+}
+
+// getInstance retrieves the go Calculator instance that is stored in an
+// _internal field_.
+func getInstance(info *v8.FunctionCallbackInfo) *Calculator {
+	var internalField *v8.Value = info.This().GetInternalField(0)
+	var handle cgo.Handle = internalField.ExternalHandle()
+	calculator, ok := handle.Value().(*Calculator)
+	if !ok {
+		panic("Not a calculator")
+	}
+	return calculator
+}
+
+func CreateJSCalculator(iso *v8.Isolate) *v8.FunctionTemplate {
+	constructor := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		calculator := &Calculator{}
+		handle := cgo.NewHandle(calculator)
+		info.This().SetInternalField(0,
+			v8.NewValueExternalHandle(iso, handle))
+		return nil
+	})
+
+	// Set the internal field count on the **instance template**.
+	instanceTemplate := constructor.InstanceTemplate()
+	instanceTemplate.SetInternalFieldCount(1)
+
+	// Create the methods on the **prototype template**.
+	prototypeTemplate := constructor.PrototypeTemplate()
+	prototypeTemplate.Set("push",
+		v8.NewFunctionTemplate(iso,
+			func(info *v8.FunctionCallbackInfo) *v8.Value {
+				calculator := getInstance(info)
+				calculator.Push(info.Args()[0].Int32())
+				return nil
+			}))
+	prototypeTemplate.Set("add",
+		v8.NewFunctionTemplate(iso,
+			func(info *v8.FunctionCallbackInfo) *v8.Value {
+				calculator := getInstance(info)
+				calculator.Add()
+				return nil
+			}))
+	prototypeTemplate.Set("peek",
+		v8.NewFunctionTemplateWithError(iso,
+			func(info *v8.FunctionCallbackInfo) (*v8.Value, error) {
+				calculator := getInstance(info)
+				return v8.NewValue(iso, calculator.Peek())
+			}))
+	return constructor
+}
+
+func ExampleNewValueExternalHandle() {
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+
+	global := v8.NewObjectTemplate(iso)
+	global.Set("Calculator", CreateJSCalculator(iso))
+	ctx := v8.NewContext(iso, global)
+
+	defer ctx.Close()
+	v, err := ctx.RunScript(`
+		const calculator = new Calculator()
+		calculator.push(7)
+		calculator.push(35)
+		calculator.add()
+		calculator.peek()`, "")
+	if err != nil {
+		fmt.Println("Error running script", err.Error())
+		return
+	}
+	fmt.Printf("The result is: %d\n", v.Integer())
+	// Output:
+	// The result is: 42
+}

--- a/object.go
+++ b/object.go
@@ -93,8 +93,25 @@ func (o *Object) SetIdx(idx uint32, val interface{}) error {
 	return nil
 }
 
-// SetInternalField sets the value of an internal field for an ObjectTemplate instance.
-// Panics if the index isn't in the range set by (*ObjectTemplate).SetInternalFieldCount.
+// SetInternalField sets the value of an internal field for an ObjectTemplate
+// instance. The object must be created from an ObjectTemplate, either from a
+// call to [ObjectTemplate.NewInstance], or as a new instance of a class. In
+// which case the object template is the [FunctionTemplate.InstanceTemplate]
+// of the constructor.
+//
+// Before setting the internal field, is is necessary to call
+// [ObjectTemplate.SetInternalFieldCount] indicating how many internal fields
+// exist.
+//
+// The function panics if the object is not created from an object template, or
+// the index is outside the range of internal field count.
+//
+// Example use cases:
+//   - An object implementing a [javascript iterator] can store the current index being iterated.
+//   - An object that exposes a native Go object to script code can store a
+//     reference. See also [NewValueExternalHandle] for this case
+//
+// [javascript iterator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols
 func (o *Object) SetInternalField(idx uint32, val interface{}) error {
 	value, err := coerceValue(o.ctx.iso, val)
 

--- a/value.cc
+++ b/value.cc
@@ -1,6 +1,7 @@
 #include "value.h"
 #include "context.h"
 #include "deps/include/v8-context.h"
+#include "deps/include/v8-external.h"
 #include "isolate-macros.h"
 #include "utils.h"
 #include "value-macros.h"
@@ -189,6 +190,16 @@ ValuePtr NewValueError(IsolatePtr iso,
   return tracked_value(ctx, val);
 }
 
+ValuePtr NewValueExternal(IsolatePtr iso, void* v) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
+  m_value* val = new m_value;
+  val->id = 0;
+  val->iso = iso;
+  val->ctx = ctx;
+  val->ptr = Global<Value>(iso, External::New(iso, v));
+  return tracked_value(ctx, val);
+}
+
 const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   Local<Uint32> array_index;
@@ -199,6 +210,11 @@ const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
   uint32_t* idx = (uint32_t*)malloc(sizeof(uint32_t));
   *idx = array_index->Value();
   return idx;
+}
+
+void* ValueToExternal(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  return value.As<External>()->Value();
 }
 
 int ValueToBoolean(ValuePtr ptr) {

--- a/value.cc
+++ b/value.cc
@@ -1,10 +1,12 @@
-#include "value.h"
+#include <stdint.h>
+
 #include "context.h"
 #include "deps/include/v8-context.h"
 #include "deps/include/v8-external.h"
 #include "isolate-macros.h"
 #include "utils.h"
 #include "value-macros.h"
+#include "value.h"
 
 #define ISOLATE_SCOPE_INTERNAL_CONTEXT(iso) \
   ISOLATE_SCOPE(iso);                       \
@@ -200,6 +202,10 @@ ValuePtr NewValueExternal(IsolatePtr iso, void* v) {
   return tracked_value(ctx, val);
 }
 
+ValuePtr NewValueExternalUintptr(IsolatePtr iso, uintptr_t v) {
+  return NewValueExternal(iso, (void*)v);
+}
+
 const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   Local<Uint32> array_index;
@@ -215,6 +221,10 @@ const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
 void* ValueToExternal(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   return value.As<External>()->Value();
+}
+
+uintptr_t ValueToExternalUintptr(ValuePtr ptr) {
+  return (uintptr_t)ValueToExternal(ptr);
 }
 
 int ValueToBoolean(ValuePtr ptr) {

--- a/value.cc
+++ b/value.cc
@@ -1,5 +1,6 @@
 #include "value.h"
 
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "context.h"
@@ -9,6 +10,7 @@
 #include "errors.h"
 #include "isolate-macros.h"
 #include "value-macros.h"
+#include "value.h"
 
 #define ISOLATE_SCOPE_INTERNAL_CONTEXT(iso) \
   ISOLATE_SCOPE(iso);                       \
@@ -225,6 +227,10 @@ ValuePtr NewValueExternal(IsolatePtr iso, void* v) {
   return tracked_value(ctx, val);
 }
 
+ValuePtr NewValueExternalUintptr(IsolatePtr iso, uintptr_t v) {
+  return NewValueExternal(iso, (void*)v);
+}
+
 const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   Local<Uint32> array_index;
@@ -240,6 +246,10 @@ const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
 void* ValueToExternal(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   return value.As<External>()->Value();
+}
+
+uintptr_t ValueToExternalUintptr(ValuePtr ptr) {
+  return (uintptr_t)ValueToExternal(ptr);
 }
 
 int ValueToBoolean(ValuePtr ptr) {

--- a/value.cc
+++ b/value.cc
@@ -5,6 +5,7 @@
 #include "context.h"
 #include "deps/include/v8-context.h"
 #include "deps/include/v8-exception.h"
+#include "deps/include/v8-external.h"
 #include "errors.h"
 #include "isolate-macros.h"
 #include "value-macros.h"
@@ -214,6 +215,16 @@ ValuePtr NewValueError(IsolatePtr iso,
   return tracked_value(ctx, val);
 }
 
+ValuePtr NewValueExternal(IsolatePtr iso, void* v) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
+  m_value* val = new m_value;
+  val->id = 0;
+  val->iso = iso;
+  val->ctx = ctx;
+  val->ptr = Global<Value>(iso, External::New(iso, v));
+  return tracked_value(ctx, val);
+}
+
 const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   Local<Uint32> array_index;
@@ -224,6 +235,11 @@ const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
   uint32_t* idx = (uint32_t*)malloc(sizeof(uint32_t));
   *idx = array_index->Value();
   return idx;
+}
+
+void* ValueToExternal(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  return value.As<External>()->Value();
 }
 
 int ValueToBoolean(ValuePtr ptr) {

--- a/value.go
+++ b/value.go
@@ -399,7 +399,7 @@ func (v *Value) IsNumber() bool {
 // IsExternal returns true if this value is an `External` object.
 func (v *Value) IsExternal() bool {
 	// TODO(rogchap): requires test case
-	return v.ctx != nil && C.ValueIsExternal(v.ptr) != 0
+	return C.ValueIsExternal(v.ptr) != 0
 }
 
 // IsInt32 returns true if this value is a 32-bit signed integer.

--- a/value.go
+++ b/value.go
@@ -167,7 +167,7 @@ func NewValueExternal(iso *Isolate, val unsafe.Pointer) *Value {
 // delete the cgo handles when the context is disposed.
 func NewValueExternalHandle(iso *Isolate, val cgo.Handle) *Value {
 	return &Value{
-		ptr: C.NewValueExternal(iso.ptr, unsafe.Pointer(&val)),
+		ptr: C.NewValueExternalUintptr(iso.ptr, C.uintptr_t(val)),
 	}
 }
 
@@ -194,11 +194,10 @@ func (v *Value) External() unsafe.Pointer {
 // invalid, but will not be detected by v8go. Prefer using only handles if
 // possible.
 func (v *Value) ExternalHandle() cgo.Handle {
-	unsafePtr := v.External()
-	if unsafePtr == nil {
+	if !v.IsExternal() {
 		return 0
 	}
-	return *(*cgo.Handle)(unsafePtr)
+	return cgo.Handle(C.ValueToExternalUintptr(v.ptr))
 }
 
 // Format implements the fmt.Formatter interface to provide a custom formatter

--- a/value.h
+++ b/value.h
@@ -54,6 +54,7 @@ typedef struct {
 
 void ValueRelease(ValuePtr ptr);
 extern void* ValueToExternal(ValuePtr prt);
+extern uintptr_t ValueToExternalUintptr(ValuePtr prt);
 extern RtnString ValueToString(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);
 int ValueToBoolean(ValuePtr ptr);
@@ -137,6 +138,7 @@ extern ValuePtr NewValueError(IsolatePtr iso_ptr,
                               ErrorTypeIndex idx,
                               const char* message);
 extern ValuePtr NewValueExternal(IsolatePtr iso_ptr, void* v);
+extern ValuePtr NewValueExternalUintptr(IsolatePtr iso_ptr, uintptr_t v);
 const char* ExceptionGetMessageString(ValuePtr ptr);
 
 extern void ObjectSet(ValuePtr ptr, const char* key, ValuePtr val_ptr);

--- a/value.h
+++ b/value.h
@@ -53,6 +53,7 @@ typedef struct {
 } RtnString;
 
 void ValueRelease(ValuePtr ptr);
+extern void* ValueToExternal(ValuePtr prt);
 extern RtnString ValueToString(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);
 int ValueToBoolean(ValuePtr ptr);
@@ -135,7 +136,7 @@ extern RtnValue NewValueBigIntFromWords(IsolatePtr iso_ptr,
 extern ValuePtr NewValueError(IsolatePtr iso_ptr,
                               ErrorTypeIndex idx,
                               const char* message);
-
+extern ValuePtr NewValueExternal(IsolatePtr iso_ptr, void* v);
 const char* ExceptionGetMessageString(ValuePtr ptr);
 
 extern void ObjectSet(ValuePtr ptr, const char* key, ValuePtr val_ptr);

--- a/value.h
+++ b/value.h
@@ -55,6 +55,7 @@ typedef struct {
 void ValueRelease(ValuePtr ptr);
 void RtnStringRelease(RtnString rtnString);
 extern void* ValueToExternal(ValuePtr prt);
+extern uintptr_t ValueToExternalUintptr(ValuePtr prt);
 extern RtnString ValueToString(ValuePtr ptr);
 extern RtnString ValueTypeOf(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);
@@ -140,6 +141,7 @@ extern ValuePtr NewValueError(IsolatePtr iso_ptr,
                               ErrorTypeIndex idx,
                               const char* message);
 extern ValuePtr NewValueExternal(IsolatePtr iso_ptr, void* v);
+extern ValuePtr NewValueExternalUintptr(IsolatePtr iso_ptr, uintptr_t v);
 const char* ExceptionGetMessageString(ValuePtr ptr);
 
 extern void ObjectSet(ValuePtr ptr, const char* key, ValuePtr val_ptr);

--- a/value.h
+++ b/value.h
@@ -54,6 +54,7 @@ typedef struct {
 
 void ValueRelease(ValuePtr ptr);
 void RtnStringRelease(RtnString rtnString);
+extern void* ValueToExternal(ValuePtr prt);
 extern RtnString ValueToString(ValuePtr ptr);
 extern RtnString ValueTypeOf(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);
@@ -138,7 +139,7 @@ extern RtnValue NewValueBigIntFromWords(IsolatePtr iso_ptr,
 extern ValuePtr NewValueError(IsolatePtr iso_ptr,
                               ErrorTypeIndex idx,
                               const char* message);
-
+extern ValuePtr NewValueExternal(IsolatePtr iso_ptr, void* v);
 const char* ExceptionGetMessageString(ValuePtr ptr);
 
 extern void ObjectSet(ValuePtr ptr, const char* key, ValuePtr val_ptr);

--- a/value_test.go
+++ b/value_test.go
@@ -6,11 +6,13 @@ package v8go_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
 	"reflect"
 	"runtime"
+	"runtime/cgo"
 	"testing"
 
 	v8 "github.com/tommie/v8go"
@@ -815,5 +817,57 @@ func TestValueArrayBufferContents(t *testing.T) {
 	_, _, err = val.SharedArrayBufferGetContents()
 	if err == nil {
 		t.Fatalf("Expected an error trying call SharedArrayBufferGetContents on value of incorrect type")
+	}
+}
+
+type InternalValue struct {
+	value int
+}
+
+func (v *InternalValue) Increment() { v.value++ }
+
+func TestValueExternalHandle(t *testing.T) {
+	t.Parallel()
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+
+	ctx := v8.NewContext(iso)
+	defer ctx.Close()
+
+	internal := &InternalValue{}
+	handle := cgo.NewHandle(internal)
+	defer handle.Delete()
+
+	ft := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		return nil
+	})
+	ft.PrototypeTemplate().
+		Set("increment", v8.NewFunctionTemplateWithError(iso, func(info *v8.FunctionCallbackInfo) (*v8.Value, error) {
+			handle := info.This().GetInternalField(0).ExternalHandle()
+			if handle == 0 {
+				return nil, errors.New("Invalid handle")
+			}
+			if instance, ok := handle.Value().(*InternalValue); ok {
+				instance.Increment()
+				return nil, nil
+			} else {
+				return nil, errors.New("Not the right type")
+			}
+		}))
+	ft.InstanceTemplate().SetInternalFieldCount(1)
+	instance, err := ft.InstanceTemplate().NewInstance(ctx)
+	if err != nil {
+		t.Fatal("Error creating instance")
+	}
+	value := v8.NewValueExternalHandle(iso, handle)
+	instance.SetInternalField(0, value)
+
+	ctx.Global().Set("internal", instance)
+	_, err = ctx.RunScript("internal.increment(); internal.increment()", "")
+	if err != nil {
+		t.Error("Error running script", err)
+	}
+	if internal.value != 2 {
+		t.Errorf("Value not incremented. Expected 2, got %d", internal.value)
 	}
 }

--- a/value_test.go
+++ b/value_test.go
@@ -6,11 +6,13 @@ package v8go_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
 	"reflect"
 	"runtime"
+	"runtime/cgo"
 	"testing"
 
 	v8 "github.com/tommie/v8go"
@@ -887,5 +889,57 @@ func TestValueTypeOf(t *testing.T) {
 	num2, _ := ctx.RunScript("0.01", "")
 	if got := num2.TypeOf(); got != "number" {
 		t.Errorf("TypeOf(0.01): expected number, got %s", got)
+	}
+}
+
+type InternalValue struct {
+	value int
+}
+
+func (v *InternalValue) Increment() { v.value++ }
+
+func TestValueExternalHandle(t *testing.T) {
+	t.Parallel()
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+
+	ctx := v8.NewContext(iso)
+	defer ctx.Close()
+
+	internal := &InternalValue{}
+	handle := cgo.NewHandle(internal)
+	defer handle.Delete()
+
+	ft := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		return nil
+	})
+	ft.PrototypeTemplate().
+		Set("increment", v8.NewFunctionTemplateWithError(iso, func(info *v8.FunctionCallbackInfo) (*v8.Value, error) {
+			handle := info.This().GetInternalField(0).ExternalHandle()
+			if handle == 0 {
+				return nil, errors.New("Invalid handle")
+			}
+			if instance, ok := handle.Value().(*InternalValue); ok {
+				instance.Increment()
+				return nil, nil
+			} else {
+				return nil, errors.New("Not the right type")
+			}
+		}))
+	ft.InstanceTemplate().SetInternalFieldCount(1)
+	instance, err := ft.InstanceTemplate().NewInstance(ctx)
+	if err != nil {
+		t.Fatal("Error creating instance")
+	}
+	value := v8.NewValueExternalHandle(iso, handle)
+	instance.SetInternalField(0, value)
+
+	ctx.Global().Set("internal", instance)
+	_, err = ctx.RunScript("internal.increment(); internal.increment()", "")
+	if err != nil {
+		t.Error("Error running script", err)
+	}
+	if internal.value != 2 {
+		t.Errorf("Value not incremented. Expected 2, got %d", internal.value)
 	}
 }


### PR DESCRIPTION
"External" values in V8 are designed to contain pointers, when a V8 ObjectTemplate acts as a proxy/wrapper for an internal object.

I exposed two different ways of accessing them, as `unsafe.Pointer` and `cgo.Handle` values; but with a strong preference to cgo Handles.

The ability to store Handles makes function callback handling significantly easier to deal with, which I am taking advantage of in the prototype to implement named/indexed property handlers.

It's actually been quite a long time since I wrote this - can't remember the details, but I can see I made a larger example demonstrating usage.

But I do see that I forgot to cleanup the handle in the example. I need to do that.